### PR TITLE
Improve tag lookup with Audible search

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ This repository contains small utilities for preparing audiobook folders for [Au
 
 | Script | Version | Path |
 |-------|---------|------|
-| `combobook.py` | v1.1 | `ABtools/combobook.py` |
+| `combobook.py` | v1.3 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.2 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v3.9 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.0 | `ABtools/search_and_tag.py` |
 
 ## `combobook.py`
-`combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library and Google Books, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files.
+`combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files.
+It now also collapses folders named like `Book Title (1 of 5)` into a single directory and names each file `Part 01`, `Part 02`, etc.
 
 ```
 # Preview only (no changes made)


### PR DESCRIPTION
## Summary
- query Audible in addition to Open Library and Google Books
- deduplicate matches and show similarity score for all
- document new search source in README
- bump `combobook.py` version
- handle `(1 of 5)` part folders when flattening

## Testing
- `python -m py_compile combobook.py`

------
https://chatgpt.com/codex/tasks/task_e_684d9e92d65083228f63ea13e72b904c