### PR TITLE
Add copy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 
 | `combobook.py` | v1.3 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.2 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v3.9 | `ABtools/restructure_for_audiobookshelf.py` |
+| `restructure_for_audiobookshelf.py` | v4.0 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.0 | `ABtools/search_and_tag.py` |
 
 ## `combobook.py`
@@ -30,4 +30,6 @@ python combobook.py "source_folder" "library_folder" --commit --yes
 ```
 
 Folders are moved to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`.
+
+The `restructure_for_audiobookshelf.py` script can also copy books when run with `--copy` alongside `--commit`.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.3 | `ABtools/combobook.py` |
+| `combobook.py` | v1.4 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.2 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.0 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.0 | `ABtools/search_and_tag.py` |
@@ -27,9 +27,12 @@ python combobook.py "source_folder" "library_folder" --commit
 
 # Tag + move and auto-confirm all matches
 python combobook.py "source_folder" "library_folder" --commit --yes
+
+# Tag + copy instead of move
+python combobook.py "source_folder" "library_folder" --commit --copy
 ```
 
 Folders are moved to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`.
 
-The `restructure_for_audiobookshelf.py` script can also copy books when run with `--copy` alongside `--commit`.
+Both `combobook.py` and `restructure_for_audiobookshelf.py` can copy books when run with `--copy` alongside `--commit`.
 


### PR DESCRIPTION
## Summary
- allow `restructure_for_audiobookshelf.py` to copy books instead of moving
- document new option and bump version in README

## Testing
- `python -m py_compile restructure_for_audiobookshelf.py`


------
https://chatgpt.com/codex/tasks/task_e_684da82748548322966094547e42f802