### PR TITLE
Add safety checks on moves and copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This repository contains small utilities for preparing audiobook folders for [Au
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.4 | `ABtools/combobook.py` |
-| `flatten_discs.py` | v1.2 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v4.0 | `ABtools/restructure_for_audiobookshelf.py` |
+| `combobook.py` | v1.5 | `ABtools/combobook.py` |
+| `flatten_discs.py` | v1.3 | `ABtools/flatten_discs.py` |
+| `restructure_for_audiobookshelf.py` | v4.1 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.0 | `ABtools/search_and_tag.py` |
 
 ## `combobook.py`

--- a/combobook.py
+++ b/combobook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/combobook.py  ·  v1.4  ·  2025-06-14
+ABtools/combobook.py  ·  v1.5  ·  2025-06-15
 
 USAGE
 -----
@@ -110,9 +110,16 @@ def leaf_dirs(root:Path)->List[Path]:
                         for c in p.iterdir())]
 
 def safe_move(src: Path, dst: Path, copy: bool = False) -> None:
-    """Move ``src`` to ``dst`` (or copy when ``copy`` is True)."""
+    """Move ``src`` to ``dst`` (or copy when ``copy`` is True) ensuring no
+    destination collision."""
+    if dst.exists():
+        raise FileExistsError(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
     if copy:
-        shutil.copytree(src, dst)
+        if src.is_dir():
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy2(src, dst)
         return
     try:
         shutil.move(str(src), str(dst))
@@ -120,8 +127,12 @@ def safe_move(src: Path, dst: Path, copy: bool = False) -> None:
         if isinstance(e, OSError) and e.errno not in (errno.EXDEV, errno.EACCES):
             raise
         rprint("  ! rename failed – copying …")
-        shutil.copytree(src, dst)
-        shutil.rmtree(src)
+        if src.is_dir():
+            shutil.copytree(src, dst)
+            shutil.rmtree(src)
+        else:
+            shutil.copy2(src, dst)
+            src.unlink()
 
 # ───────────── existing tag reader ──────────────────────────────────────────
 def tags_from_track(track:Path)->Optional[Meta]:

--- a/flatten_discs.py
+++ b/flatten_discs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/flatten_discs.py  –  v1.2  (2025-05-28)
+ABtools/flatten_discs.py  –  v1.3  (2025-06-15)
 
 Flatten audiobook rips that live in
     Book Name (Disc 01)  /  Book Name (Disc 02)  …
@@ -13,6 +13,13 @@ from __future__ import annotations
 import argparse, re, shutil, sys
 from pathlib import Path
 from typing import List, Tuple
+
+def safe_move(src: Path, dst: Path) -> None:
+    """Move ``src`` to ``dst`` ensuring ``dst`` does not exist."""
+    if dst.exists():
+        raise FileExistsError(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(src), str(dst))
 
 AUDIO_EXTS = {".mp3", ".m4b", ".m4a", ".flac", ".ogg", ".opus"}
 
@@ -71,7 +78,7 @@ def flatten(parent: Path, discs: List[Tuple[int, Path]],
         print(f"   {'mv' if not dry else '↪'} {src.name} → {dest.relative_to(parent)}")
         if not dry:
             book_dir.mkdir(exist_ok=True)
-            shutil.move(str(src), str(dest))
+            safe_move(src, dest)
 
     if not dry:
         for _, d in discs:


### PR DESCRIPTION
## Summary
- improve README table with updated versions
- bump versions on python scripts
- guard move/copy operations with new safe_move helper

## Testing
- `python -m py_compile combobook.py flatten_discs.py restructure_for_audiobookshelf.py search_and_tag.py`

------
https://chatgpt.com/codex/tasks/task_e_684dad7933488322aeba00f1cb6407e6