### PR TITLE
Add Audible lookup to search_and_tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 | `combobook.py` | v1.5 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.3 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.1 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.0 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.1 | `ABtools/search_and_tag.py` |
 
 ## `combobook.py`
 `combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files.


### PR DESCRIPTION
## Summary
- update search_and_tag to v2.1
- check Audible first when tagging and store series if available
- tag series data in mp3/mp4 files
- document new version in README

## Testing
- `python3 -m py_compile search_and_tag.py`
- `python3 -m py_compile combobook.py flatten_discs.py restructure_for_audiobookshelf.py`


------
https://chatgpt.com/codex/tasks/task_e_684e7078417c83229a560d9ef22e05b5