### PR TITLE
Fix mutagen path usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This repository contains small utilities for preparing audiobook folders for [Au
 | `restructure_for_audiobookshelf.py` | v4.1 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.3 | `ABtools/search_and_tag.py` |
 
+Run any script with `--version` to print its version and file location.
+
 ## `combobook.py`
 `combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files.
 
@@ -47,4 +49,11 @@ folder path is written to `review_log.txt` for later inspection. On
 successful tagging, the metadata is exported to `metadata.json` and
 `book.nfo` so other players (including Audiobookshelf) can read the
 details.
+
+
+## `flatten_discs.py`
+`flatten_discs.py` merges disc-numbered rips into one folder with sequential track names. Preview changes by default; use `--commit` to apply them and `--yes` to auto-confirm.
+
+## `restructure_for_audiobookshelf.py`
+`restructure_for_audiobookshelf.py` reorganizes a source collection into Audiobookshelf layout. It injects basic tags from folder names when needed, flattens disc folders, and moves or copies books to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`. Run with `--commit` to perform the move and `--copy` to duplicate instead.
 

--- a/combobook.py
+++ b/combobook.py
@@ -26,6 +26,10 @@ from typing import List, Optional
 from difflib import SequenceMatcher
 import errno
 
+VERSION = "1.5"
+FILE_PATH = Path(__file__).resolve()
+VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
+
 # ───────────── configuration ────────────────────────────────────────────────
 AUDIO_EXTS   = {".mp3", ".m4b", ".m4a", ".flac", ".ogg", ".opus"}
 FLATTEN_DISCS = True
@@ -137,7 +141,7 @@ def safe_move(src: Path, dst: Path, copy: bool = False) -> None:
 # ───────────── existing tag reader ──────────────────────────────────────────
 def tags_from_track(track:Path)->Optional[Meta]:
     try:
-        au = MFile(track, easy=True)
+        au = MFile(str(track), easy=True)
     except mutagen.MutagenError:
         return None
     if not au or "artist" not in au or "album" not in au:
@@ -536,6 +540,7 @@ if __name__=="__main__":
     ap.add_argument("--commit", action="store_true")
     ap.add_argument("--yes",    action="store_true")
     ap.add_argument("--copy",   action="store_true", help="Copy instead of move when used with --commit")
+    ap.add_argument("--version", action="version", version=VERSION_INFO)
     args=ap.parse_args()
     SRC=args.source_root.resolve(); LIB=args.library_root.resolve()
     if not SRC.is_dir(): sys.exit("source_root not found")

--- a/flatten_discs.py
+++ b/flatten_discs.py
@@ -14,6 +14,10 @@ import argparse, re, shutil, sys
 from pathlib import Path
 from typing import List, Tuple
 
+VERSION = "1.3"
+FILE_PATH = Path(__file__).resolve()
+VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
+
 def safe_move(src: Path, dst: Path) -> None:
     """Move ``src`` to ``dst`` ensuring ``dst`` does not exist."""
     if dst.exists():
@@ -115,6 +119,7 @@ if __name__ == "__main__":
     ap.add_argument("root", type=Path, help="Top-level audiobook folder")
     ap.add_argument("--commit", action="store_true", help="Actually move/rename (default: preview)")
     ap.add_argument("--yes",    action="store_true", help="Auto-confirm every book")
+    ap.add_argument("--version", action="version", version=VERSION_INFO)
     args = ap.parse_args()
     ROOT = args.root.resolve()
     if not ROOT.is_dir():

--- a/restructure_for_audiobookshelf.py
+++ b/restructure_for_audiobookshelf.py
@@ -21,6 +21,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
+VERSION = "4.1"
+FILE_PATH = Path(__file__).resolve()
+VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
+
 # ───────── configuration ─────────
 AUDIO_EXTS: set[str]       = {".mp3", ".m4b", ".m4a", ".flac", ".ogg", ".opus"}
 RENAME_TRACKS              = True       # rename Track 001.* … inside each book?
@@ -99,7 +103,7 @@ TAG_MAP = {
 
 def read_tags(track: Path) -> Optional[BookMeta]:
     try:
-        audio = MFile(track, easy=True)
+        audio = MFile(str(track), easy=True)
     except MutagenError:
         return None
     if not audio:
@@ -359,5 +363,6 @@ if __name__ == "__main__":
         action="store_true",
         help="Copy instead of move when --commit is used",
     )
+    ap.add_argument("--version", action="version", version=VERSION_INFO)
     args = ap.parse_args()
     main(args.source_root, args.library_root, args.commit, args.copy)

--- a/search_and_tag.py
+++ b/search_and_tag.py
@@ -25,6 +25,10 @@ import argparse, datetime, re, sys, textwrap
 from pathlib import Path
 from typing import Optional, Tuple, List
 
+VERSION = "2.3"
+FILE_PATH = Path(__file__).resolve()
+VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
+
 import requests
 from rapidfuzz import fuzz
 import json
@@ -175,7 +179,7 @@ def best_match(author: Optional[str], title: str) -> Optional[tuple[int, dict]]:
 
 # ───── tag / strip functions ─────
 def strip_tags(file: Path):
-    audio = MFile(file)
+    audio = MFile(str(file))
     if audio:
         audio.delete(); audio.save()
 
@@ -183,7 +187,7 @@ def write_tags(file: Path, meta: dict):
     ext = file.suffix.lower()
     if ext == ".mp3":
         try:
-            audio = ID3(file)
+            audio = ID3(str(file))
         except ID3NoHeaderError:
             audio = ID3()
         audio.clear()
@@ -194,9 +198,9 @@ def write_tags(file: Path, meta: dict):
             audio["TDRC"] = TDRC(3, meta["year"])
         if meta.get("series"):
             audio.add(TXXX(3, desc="series", text=meta["series"]))
-        audio.save(file)
+        audio.save(str(file))
     elif ext in {".m4a", ".m4b"}:
-        mp4 = MP4(file)
+        mp4 = MP4(str(file))
         mp4.clear()
         mp4["©nam"] = meta["title"]
         mp4["©alb"] = meta["title"]
@@ -318,6 +322,7 @@ def main():
     ap.add_argument("--commit",    action="store_true")
     ap.add_argument("--yes",       action="store_true")
     ap.add_argument("--striptags", action="store_true")
+    ap.add_argument("--version", action="version", version=VERSION_INFO)
     args = ap.parse_args()
 
     if not args.root.exists():


### PR DESCRIPTION
## Summary
- convert Path objects to strings before passing to mutagen
- ensure read_tags works with Path

## Testing
- `python -m py_compile combobook.py flatten_discs.py restructure_for_audiobookshelf.py search_and_tag.py`


------
https://chatgpt.com/codex/tasks/task_e_684e8b76401483228dc10c32ca3e231e