### PR TITLE
Adjust log path for search_and_tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 | `combobook.py` | v1.5 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.3 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.1 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.3 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.4 | `ABtools/search_and_tag.py` |
 
 Run any script with `--version` to print its version and file location.
 
@@ -45,7 +45,8 @@ and automatically applies it. Matches with a low score will ask for
 confirmation unless you pass `--yes`.
 
 When a book has no match or you decline the suggested metadata, the
-folder path is written to `review_log.txt` for later inspection. On
+folder path is written to `review_log.txt` in the chosen root folder for
+later inspection. All actions are logged to `tag_log.txt` beside it. On
 successful tagging, the metadata is exported to `metadata.json` and
 `book.nfo` so other players (including Audiobookshelf) can read the
 details.

--- a/search_and_tag.py
+++ b/search_and_tag.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """
-ABtools/search_and_tag.py – v2.3  (2025-07-01)
+ABtools/search_and_tag.py – v2.4  (2025-07-15)
 Tag (or strip) audiobook files using multiple metadata providers.
 
 The script queries Audible, Open Library and Google Books, ranks the
 results using fuzzy title matching and automatically tags files with the
 best match. Low scoring hits will prompt for confirmation unless you
-run with ``--yes``.
+run with ``--yes``. Log files are written next to the chosen root as
+``tag_log.txt`` and ``review_log.txt``.
 
 examples
 --------
@@ -25,7 +26,7 @@ import argparse, datetime, re, sys, textwrap
 from pathlib import Path
 from typing import Optional, Tuple, List
 
-VERSION = "2.3"
+VERSION = "2.4"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -324,6 +325,11 @@ def main():
     ap.add_argument("--striptags", action="store_true")
     ap.add_argument("--version", action="version", version=VERSION_INFO)
     args = ap.parse_args()
+
+    global LOG_PATH, REVIEW_PATH
+    base = args.root if args.root.is_dir() else args.root.parent
+    LOG_PATH = base / "tag_log.txt"
+    REVIEW_PATH = base / "review_log.txt"
 
     if not args.root.exists():
         sys.exit("path not found")


### PR DESCRIPTION
## Summary
- drop log files next to the selected root directory
- document new log location and bump search_and_tag version

## Testing
- `python -m py_compile search_and_tag.py combobook.py flatten_discs.py restructure_for_audiobookshelf.py`

------
https://chatgpt.com/codex/tasks/task_e_684e91fb787c83229e338ff29d1eb48f