### PR TITLE
Add scaffold doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,20 @@ This repository contains small utilities for preparing audiobook folders for [Au
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.5 | `ABtools/combobook.py` |
-| `flatten_discs.py` | v1.3 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v4.1 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.4 | `ABtools/search_and_tag.py` |
+| `combobook.py` | v1.6 | `ABtools/combobook.py` |
+| `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
+| `restructure_for_audiobookshelf.py` | v4.2 | `ABtools/restructure_for_audiobookshelf.py` |
+| `search_and_tag.py` | v2.5 | `ABtools/search_and_tag.py` |
 
 Run any script with `--version` to print its version and file location.
+For example:
+
+```bash
+python search_and_tag.py --version
+# search_and_tag.py v2.5 (/path/to/ABtools/search_and_tag.py)
+```
+
+See [scaffold.md](scaffold.md) for a quick reference to all scripts and their versions.
 
 ## `combobook.py`
 `combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files.

--- a/combobook.py
+++ b/combobook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/combobook.py  ·  v1.5  ·  2025-06-15
+ABtools/combobook.py  ·  v1.6  ·  2025-06-15
 
 USAGE
 -----
@@ -15,6 +15,9 @@ python combo_abooks.py  "E:\\Audio Books"  "G:\\AudiobookShelf"  --commit  --cop
 
 # tag + move, auto-accept every hit
 python combo_abooks.py  "E:\\Audio Books"  "G:\\AudiobookShelf"  --commit  --yes
+
+# show version and file location
+python combo_abooks.py --version
 """
 
 from __future__ import annotations
@@ -26,7 +29,7 @@ from typing import List, Optional
 from difflib import SequenceMatcher
 import errno
 
-VERSION = "1.5"
+VERSION = "1.6"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -365,7 +368,7 @@ def flatten(folder: Path, dry: bool):
             rprint(f"    {'mv' if not dry else '↪'} {src.name} → {dest.name}")
             if not dry:
                 dest.parent.mkdir(exist_ok=True)
-                shutil.move(src, dest)
+                shutil.move(str(src), str(dest))
     else:
         digits = len(str(len(tracks)))
         for i, (num, src) in enumerate(tracks, 1):
@@ -373,7 +376,7 @@ def flatten(folder: Path, dry: bool):
             rprint(f"    {'mv' if not dry else '↪'} {src.name} → {dest.name}")
             if not dry:
                 dest.parent.mkdir(exist_ok=True)
-                shutil.move(src, dest)
+                shutil.move(str(src), str(dest))
 
     if not dry:
         for _, d in discs:

--- a/flatten_discs.py
+++ b/flatten_discs.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """
-ABtools/flatten_discs.py  –  v1.3  (2025-06-15)
+ABtools/flatten_discs.py  –  v1.4  (2025-06-15)
 
 Flatten audiobook rips that live in
     Book Name (Disc 01)  /  Book Name (Disc 02)  …
 creating one folder called  Book Name/Track 001.* …
 
 • Preview by default.  Add  --commit  to do it,  --yes  to skip prompts.
+• ``--version`` prints the script version and file path.
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ import argparse, re, shutil, sys
 from pathlib import Path
 from typing import List, Tuple
 
-VERSION = "1.3"
+VERSION = "1.4"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 

--- a/restructure_for_audiobookshelf.py
+++ b/restructure_for_audiobookshelf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/restructure_for_audiobookshelf.py – v4.1  (2025-06-15)
+ABtools/restructure_for_audiobookshelf.py – v4.2  (2025-06-15)
 Use restructure_for_audiobookshelf.py "Source folder" "Destination folder" --commit 
 • Recursively scans source_root; every directory that *contains* audio but whose
   sub-directories don’t is treated as one “book”.
@@ -12,6 +12,7 @@ Use restructure_for_audiobookshelf.py "Source folder" "Destination folder" --com
 
       <library_root>/Author/Series?/Vol # - YYYY - Title {Narrator}/
 • Add --copy to duplicate folders instead of moving them
+• ``--version`` prints the script version and file path
 """
 
 from __future__ import annotations
@@ -21,7 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
-VERSION = "4.1"
+VERSION = "4.2"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -64,22 +65,22 @@ def safe_move(src: Path, dst: Path, copy: bool = False) -> None:
     dst.parent.mkdir(parents=True, exist_ok=True)
     if copy:
         if src.is_dir():
-            shutil.copytree(src, dst)
+            shutil.copytree(str(src), str(dst))
         else:
-            shutil.copy2(src, dst)
+            shutil.copy2(str(src), str(dst))
         return
     try:
-        shutil.move(src, dst)
+        shutil.move(str(src), str(dst))
     except (PermissionError, OSError) as e:
         # Windows “access denied / file in use” or cross-device rename → copy
         if isinstance(e, OSError) and e.errno not in (errno.EXDEV, errno.EACCES):
             raise
         print("  ! rename failed – copying …")
         if src.is_dir():
-            shutil.copytree(src, dst)
+            shutil.copytree(str(src), str(dst))
             shutil.rmtree(src)
         else:
-            shutil.copy2(src, dst)
+            shutil.copy2(str(src), str(dst))
             src.unlink()
 
 # ───────── metadata ─────────

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,0 +1,22 @@
+# ABtools Scaffold
+
+This repository holds a few standalone scripts for preparing and tagging audiobooks. Each script embeds a version number and file location so you can check exactly which copy you are running.
+
+## Scripts
+
+| Script | Version | Path |
+|-------|---------|------|
+| `combobook.py` | v1.6 | `ABtools/combobook.py` |
+| `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
+| `restructure_for_audiobookshelf.py` | v4.2 | `ABtools/restructure_for_audiobookshelf.py` |
+| `search_and_tag.py` | v2.5 | `ABtools/search_and_tag.py` |
+
+Run any script with `--version` to print something like:
+
+```bash
+python combobook.py --version
+# combobook.py v1.6 (/full/path/to/ABtools/combobook.py)
+```
+
+The files live directly in the `ABtools` directory alongside this document and the main `README.md`.
+

--- a/search_and_tag.py
+++ b/search_and_tag.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/search_and_tag.py – v2.4  (2025-07-15)
+ABtools/search_and_tag.py – v2.5  (2025-07-15)
 Tag (or strip) audiobook files using multiple metadata providers.
 
 The script queries Audible, Open Library and Google Books, ranks the
@@ -8,6 +8,7 @@ results using fuzzy title matching and automatically tags files with the
 best match. Low scoring hits will prompt for confirmation unless you
 run with ``--yes``. Log files are written next to the chosen root as
 ``tag_log.txt`` and ``review_log.txt``.
+Use ``--version`` to print the script version and file location.
 
 examples
 --------
@@ -26,7 +27,7 @@ import argparse, datetime, re, sys, textwrap
 from pathlib import Path
 from typing import Optional, Tuple, List
 
-VERSION = "2.4"
+VERSION = "2.5"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 


### PR DESCRIPTION
## Summary
- update scaffold and README with version info
- show script path consistently when tagging
- fix moving files with bytes paths
- bump script versions to expose change

## Testing
- `python -m py_compile combobook.py flatten_discs.py restructure_for_audiobookshelf.py search_and_tag.py`


------
https://chatgpt.com/codex/tasks/task_e_684ea54331ac83229bcf9c7104043d87