### PR TITLE
Update search prompt default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ pip install -r requirements.txt
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.5 | `ABtools/combobook.py` |
-| `flatten_discs.py` | v1.3 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v4.1 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.4 | `ABtools/search_and_tag.py` |
+| `combobook.py` | v1.6 | `ABtools/combobook.py` |
+| `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
+| `restructure_for_audiobookshelf.py` | v4.2 | `ABtools/restructure_for_audiobookshelf.py` |
+| `search_and_tag.py` | v2.6 | `ABtools/search_and_tag.py` |
 
 Run any script with `--version` to print its version and file location.
 
@@ -67,7 +67,8 @@ Both `combobook.py` and `restructure_for_audiobookshelf.py` can copy books when 
 `search_and_tag.py` tags or strips audiobook files. It queries Audible,
 Open Library and Google Books, chooses the best match via fuzzy scoring
 and automatically applies it. Matches with a low score will ask for
-confirmation unless you pass `--yes`.
+confirmation unless you pass `--yes`. The prompt defaults to `no` so
+low-confidence matches aren't accepted accidentally.
 
 When a book has no match or you decline the suggested metadata, the
 folder path is written to `review_log.txt` in the chosen root folder for

--- a/scaffold.md
+++ b/scaffold.md
@@ -16,6 +16,9 @@ Audiobooks/
 
 ## Scripts Overview
 
+All scripts support `--version` which prints their version number and
+file path.
+
 ### `search_and_tag.py`
 
 - Tags audio files using best match from:

--- a/search_and_tag.py
+++ b/search_and_tag.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
-ABtools/search_and_tag.py – v2.5  (2025-07-15)
+ABtools/search_and_tag.py – v2.6  (2025-07-22)
 Tag (or strip) audiobook files using multiple metadata providers.
 
 The script queries Audible, Open Library and Google Books, ranks the
 results using fuzzy title matching and automatically tags files with the
 best match. Low scoring hits will prompt for confirmation unless you
-run with ``--yes``. Log files are written next to the chosen root as
-``tag_log.txt`` and ``review_log.txt``.
+run with ``--yes``. When prompted, the default answer is "No" so low
+confidence matches won't be accepted accidentally. Log files are written
+next to the chosen root as ``tag_log.txt`` and ``review_log.txt``.
 Use ``--version`` to print the script version and file location.
 
 examples
@@ -27,7 +28,7 @@ import argparse, datetime, re, sys, textwrap
 from pathlib import Path
 from typing import Optional, Tuple, List
 
-VERSION = "2.5"
+VERSION = "2.6"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -268,9 +269,9 @@ def process_leaf(path: Path, args):
         rprint("  [yellow]⚠ low confidence – double-check[/]")
     if score < 70 and not args.yes:
         if hasattr(Confirm, "ask"):
-            proceed = Confirm.ask("  tag with this metadata?")
+            proceed = Confirm.ask("  tag with this metadata?", default=False)
         else:
-            proceed = Confirm("tag with this metadata?")
+            proceed = Confirm("tag with this metadata?", default=False)
         if not proceed:
             log("SKIP", str(path))
             review_log(path, "user_skip")


### PR DESCRIPTION
## Summary
- default `search_and_tag.py` confirmation now defaults to "no" on low confidence
- document `--version` support in scaffold
- keep README versions in sync and mention new default behavior

## Testing
- `python -m py_compile search_and_tag.py combobook.py flatten_discs.py restructure_for_audiobookshelf.py`
- `python search_and_tag.py --version` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684eafcc009083229848c7bc29ce9bbc