### PR TITLE
Fix mp4 tag bug and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Install all dependencies with:
 
 ```bash
 pip install -r requirements.txt
+```
+
 ## Scripts
 
 | Script | Version | Path |
@@ -35,7 +37,7 @@ pip install -r requirements.txt
 | `combobook.py` | v1.6 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.2 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.8 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.9 | `ABtools/search_and_tag.py` |
 
 Run any script with `--version` to print its version and file location.
 

--- a/scaffold.md
+++ b/scaffold.md
@@ -71,5 +71,5 @@ file path.
 | `combobook.py` | v1.6 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.2 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.8 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.9 | `ABtools/search_and_tag.py` |
 

--- a/search_and_tag.py
+++ b/search_and_tag.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/search_and_tag.py – v2.8  (2025-07-22)
+ABtools/search_and_tag.py – v2.9  (2025-07-31)
 Tag (or strip) audiobook files using multiple metadata providers.
 
     The script queries Audible, Open Library and Google Books, ranks the
@@ -32,7 +32,7 @@ import argparse, datetime, re, sys, textwrap
 from pathlib import Path
 from typing import Optional, Tuple, List
 
-VERSION = "2.8"
+VERSION = "2.9"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -217,7 +217,7 @@ def write_tags(file: Path, meta: dict):
         if meta["year"]:
             mp4["©day"] = meta["year"]
         if meta.get("series"):
-            mp4["----:com.apple.iTunes:series"] = [meta["series"]]
+            mp4["----:com.apple.iTunes:series"] = [meta["series"].encode("utf-8")]
         mp4.save()
 
 def export_metadata(path: Path, meta: dict):


### PR DESCRIPTION
## Summary
- fix issue tagging MP4 "series" field
- bump search_and_tag.py to v2.9
- document script versions and file paths
- close README code block

## Testing
- `python search_and_tag.py --version`
- `python combobook.py --version`
- `python flatten_discs.py --version`
- `python restructure_for_audiobookshelf.py --version`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684eb4c32efc832293caf161b65eac75