### PR TITLE
Improve filename parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install -r requirements.txt
 | `combobook.py` | v1.6 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.2 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.9 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.10 | `ABtools/search_and_tag.py` |
 
 Run any script with `--version` to print its version and file location.
 

--- a/scaffold.md
+++ b/scaffold.md
@@ -71,5 +71,5 @@ file path.
 | `combobook.py` | v1.6 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.2 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.9 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.10 | `ABtools/search_and_tag.py` |
 

--- a/search_and_tag.py
+++ b/search_and_tag.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/search_and_tag.py – v2.9  (2025-07-31)
+ABtools/search_and_tag.py – v2.10  (2025-08-01)
 Tag (or strip) audiobook files using multiple metadata providers.
 
     The script queries Audible, Open Library and Google Books, ranks the
@@ -32,7 +32,7 @@ import argparse, datetime, re, sys, textwrap
 from pathlib import Path
 from typing import Optional, Tuple, List
 
-VERSION = "2.9"
+VERSION = "2.10"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -92,8 +92,13 @@ def guess_from_path(p: Path) -> Tuple[Optional[str], str, Optional[str]]:
     if (m := YEAR_RX.match(leaf)):
         year, leaf = m.group(1), leaf[m.end():].lstrip(" -_")
     parts = [x.strip() for x in leaf.split(" - ")]
-    if len(parts) == 2 and " " in parts[1]:
-        title, author = parts
+    if parts and re.fullmatch(r"\d+", parts[0]):
+        parts = parts[1:]
+    if parts and re.fullmatch(r"\d{4}", parts[-1]) and year is None:
+        year = parts.pop()
+    if len(parts) >= 2:
+        title = " - ".join(parts[:-1])
+        author = parts[-1] if " " in parts[-1] else None
     else:
         title, author = leaf, None
     if not author:


### PR DESCRIPTION
## Summary
- improve metadata parsing for filenames like `86 - Title - Author - 1884`
- bump `search_and_tag.py` version to 2.10
- keep version tables in README and scaffold in sync

## Testing
- `python -m py_compile combobook.py flatten_discs.py restructure_for_audiobookshelf.py search_and_tag.py`

------
https://chatgpt.com/codex/tasks/task_e_684eb801968883228269ddeaa7e2b1d1