### PR TITLE
Preserve part numbering in restructure tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 - Provides preview and logging
 - Optionally prompts for confirmation or proceeds automatically
 - Fetches metadata in parallel for faster tagging
+- Preserves part numbers like `(1 of 6)` when reorganizing files
 
 ## Requirements
 
@@ -37,7 +38,7 @@ pip install -r requirements.txt
 
 | `combobook.py` | v1.6 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v4.3 | `ABtools/restructure_for_audiobookshelf.py` |
+| `restructure_for_audiobookshelf.py` | v4.4 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.11 | `ABtools/search_and_tag.py` |
 
 Run any script with `--version` to print its version and file location.
@@ -109,6 +110,6 @@ details.
 `flatten_discs.py` merges disc-numbered rips into one folder with sequential track names. Preview changes by default; use `--commit` to apply them and `--yes` to auto-confirm.
 
 ## `restructure_for_audiobookshelf.py`
-`restructure_for_audiobookshelf.py` reorganizes a source collection into Audiobookshelf layout. It reads tags from the audio files first, then `book.nfo`, and finally falls back to folder names. Disc folders are flattened and books are moved or copied to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`. Metadata matching is handled by `search_and_tag.py`.
+`restructure_for_audiobookshelf.py` reorganizes a source collection into Audiobookshelf layout. It reads tags from the audio files first, then `book.nfo`, and finally falls back to folder names. Disc folders are flattened and books are moved or copied to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`. Part suffixes like `(1 of 6)` or `Part 1` are preserved when moving files. Metadata matching is handled by `search_and_tag.py`.
 
 

--- a/restructure_for_audiobookshelf.py
+++ b/restructure_for_audiobookshelf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/restructure_for_audiobookshelf.py – v4.3  (2025-06-15)
+ABtools/restructure_for_audiobookshelf.py – v4.4  (2025-06-15)
 Use restructure_for_audiobookshelf.py "Source folder" "Destination folder" --commit 
 • Recursively scans source_root; every directory that *contains* audio but whose
   sub-directories don’t is treated as one “book”.
@@ -13,6 +13,7 @@ Use restructure_for_audiobookshelf.py "Source folder" "Destination folder" --com
       <library_root>/Author/Series?/Vol # - YYYY - Title {Narrator}/
 • Add --copy to duplicate folders instead of moving them
 • ``--version`` prints the script version and file path
+• Part suffixes like “(1 of 6)” or “Part 1” are preserved when moving
 """
 
 from __future__ import annotations
@@ -23,7 +24,7 @@ from pathlib import Path
 from typing import List, Optional
 import xml.etree.ElementTree as ET
 
-VERSION = "4.3"
+VERSION = "4.4"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -191,7 +192,7 @@ REGEX_PATTERNS: list[re.Pattern[str]] = [
 ]
 CLEAN_TAIL_RX = re.compile(
     r"""                      # strip from the right end:
-        (?:\s*\([^)]*\))?         #  (Lee)  or any (...) narrator
+        (?:\s*\((?!(?:\d+\s*of\s*\d+|[Pp]art\s*\d+))[^)]*\))?  #  (Lee) but keep (1 of 6) / (Part 1)
         (?:\s*\d+\s*[kK])?        #  64k / 128K  bitrate
         (?:\s*\d+\.\d{2}\.\d{2})? #  12.56.09  (h.mm.ss)
         (?:\s*\{[^}]*\})?         #  {303mb}

--- a/scaffold.md
+++ b/scaffold.md
@@ -47,6 +47,11 @@ file path.
   - Creates cleaned-up `Author/Year - Title` folder
   - Moves and renames content
 
+### `restructure_for_audiobookshelf.py`
+
+- Reorganizes existing folders into Audiobookshelf layout
+- Keeps numeric part suffixes like `(1 of 6)` or `Part 1` when moving files
+
 ## Regex Patterns Used
 
 - `^(\d{4})\s*[-_]\s*`: extracts leading year
@@ -71,6 +76,6 @@ file path.
 |-------|---------|------|
 | `combobook.py` | v1.6 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v4.3 | `ABtools/restructure_for_audiobookshelf.py` |
+| `restructure_for_audiobookshelf.py` | v4.4 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.11 | `ABtools/search_and_tag.py` |
 


### PR DESCRIPTION
## Summary
- support part suffixes `(1 of 6)` or `Part 1` when cleaning titles
- bump `restructure_for_audiobookshelf.py` version to 4.4
- document new functionality in README and scaffold

## Testing
- `python -m py_compile combobook.py flatten_discs.py search_and_tag.py restructure_for_audiobookshelf.py`

------
https://chatgpt.com/codex/tasks/task_e_684ec6f4dd948322a92fb35fc2358534