### PR TITLE
Enhance restructure_for_audiobookshelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This repository contains small utilities for preparing audiobook folders for [Au
 
 - Automatically tags `.mp3`, `.m4a`, and `.m4b` files with metadata
 - Uses data from Audible, OpenLibrary, and Google Books
-- Reorganizes folders into a clean structure: `Author/Year - Title`
+- Reorganizes folders into a clean structure using metadata from tags,
+  `metadata.json` or `book.nfo`: `Author/Year - Title`
 - Strips old or broken tags if needed
 - Writes metadata to both `metadata.json` and `book.nfo` (for Kodi-style readers)
 - Provides preview and logging
@@ -39,7 +40,7 @@ pip install -r requirements.txt
 
 | `combobook.py` | v1.7 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v4.5 | `ABtools/restructure_for_audiobookshelf.py` |
+| `restructure_for_audiobookshelf.py` | v4.6 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.12 | `ABtools/search_and_tag.py` |
 
 Run any script with `--version` to print its version and file location.
@@ -111,6 +112,6 @@ details.
 `flatten_discs.py` merges disc-numbered rips into one folder with sequential track names. Preview changes by default; use `--commit` to apply them and `--yes` to auto-confirm.
 
 ## `restructure_for_audiobookshelf.py`
-`restructure_for_audiobookshelf.py` reorganizes a source collection into Audiobookshelf layout. It reads tags from the audio files first, then `book.nfo`, and finally falls back to folder names. Disc folders are flattened and books are moved or copied to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`. Part suffixes like `(1 of 6)` or `Part 1` are preserved when moving files. Metadata matching is handled by `search_and_tag.py`.
+`restructure_for_audiobookshelf.py` reorganizes a source collection into Audiobookshelf layout. It reads tags from the audio files first, then `metadata.json` or `book.nfo`, and finally falls back to folder names. Disc folders are flattened and books are moved or copied to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`. Part suffixes like `(1 of 6)` or `Part 1` are preserved when moving files. Metadata matching is handled by `search_and_tag.py`.
 
 

--- a/scaffold.md
+++ b/scaffold.md
@@ -47,7 +47,8 @@ Audiobooks/
 
 ### `restructure_for_audiobookshelf.py`
 
-- Reorganizes existing folders into Audiobookshelf layout
+- Reorganizes existing folders into Audiobookshelf layout using metadata from
+  tags, `metadata.json` or `book.nfo`
 - Keeps numeric part suffixes like `(1 of 6)` or `Part 1` when moving files
 - Writes `track` or `trkn` tags so players keep the right order
 
@@ -75,6 +76,6 @@ Audiobooks/
 |-------|---------|------|
 | `combobook.py` | v1.7 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v4.5 | `ABtools/restructure_for_audiobookshelf.py` |
+| `restructure_for_audiobookshelf.py` | v4.6 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.12 | `ABtools/search_and_tag.py` |
 


### PR DESCRIPTION
## Summary
- use metadata.json when restructuring collections
- bump version to v4.6 and document new behavior
- note metadata.json in README and scaffold

## Testing
- `python -m py_compile restructure_for_audiobookshelf.py`

------
https://chatgpt.com/codex/tasks/task_e_684ed709f02883229fbcc9b80fdf7d5a