### PR TITLE
Fix missing TRCK import

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 - Adds track numbers so multi-part books play in order
 - Detects series and volume numbers with fuzzy matching
   and prompts for confirmation when run with `--interactive`
+- Each script reports its version and location with `--version`
 
 ## Requirements
 
@@ -43,7 +44,7 @@ pip install -r requirements.txt
 | `combobook.py` | v1.7 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.12 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.13 | `ABtools/search_and_tag.py` |
 
 Run any script with `--version` to print its version and file location.
 

--- a/scaffold.md
+++ b/scaffold.md
@@ -28,8 +28,9 @@ Audiobooks/
   - `metadata.json`
   - `book.nfo`
   - `--debug` prints tracebacks on errors
-  - `--no` auto-declines metadata suggestions
-  - fetches metadata in parallel for faster processing
+- `--no` auto-declines metadata suggestions
+- fetches metadata in parallel for faster processing
+- `--version` prints the script version and file path
 
 ### `flatten_discs.py`
 
@@ -80,5 +81,5 @@ Audiobooks/
 | `combobook.py` | v1.7 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.12 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.13 | `ABtools/search_and_tag.py` |
 

--- a/search_and_tag.py
+++ b/search_and_tag.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/search_and_tag.py – v2.12  (2025-09-01)
+ABtools/search_and_tag.py – v2.13  (2025-09-01)
 Tag (or strip) audiobook files using multiple metadata providers.
 
     The script queries Audible, Open Library and Google Books, ranks the
@@ -32,7 +32,7 @@ import argparse, datetime, re, sys, textwrap
 from pathlib import Path
 from typing import Optional, Tuple, List
 
-VERSION = "2.12"
+VERSION = "2.13"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -45,7 +45,7 @@ from rapidfuzz import fuzz
 import json
 import xml.etree.ElementTree as ET
 from mutagen import File as MFile, MutagenError
-from mutagen.id3 import ID3, ID3NoHeaderError, TIT2, TALB, TPE1, TDRC, TXXX
+from mutagen.id3 import ID3, ID3NoHeaderError, TIT2, TALB, TPE1, TDRC, TXXX, TRCK
 from mutagen.mp4 import MP4, MP4StreamInfoError
 from bs4 import BeautifulSoup
 


### PR DESCRIPTION
## Summary
- add missing TRCK import in `search_and_tag.py`
- bump `search_and_tag.py` version to 2.13
- document `--version` behaviour in scaffold and README
- update version tables

## Testing
- `python search_and_tag.py --version`
- `python -m py_compile search_and_tag.py`
- `python -m py_compile combobook.py flatten_discs.py restructure_for_audiobookshelf.py`


------
https://chatgpt.com/codex/tasks/task_e_684f2aa8c8b48322b348d5983dd00397