### PR TITLE
Add name-based duplicate search

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This repository contains small utilities for preparing audiobook folders for [Au
 - Each script reports its version and location with `--version`
 - Experimental features are toggled via `~/.abclient.json` using `AbClient`
 - Prints the score from each metadata provider during tagging
-- `find_duplicates.py` shows progress while scanning
+- `find_duplicates.py` shows progress while scanning and can compare
+  files by SHA1 hash or by name
 
 ## Requirements
 
@@ -48,7 +49,7 @@ pip install -r requirements.txt
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |
-| `find_duplicates.py` | v0.3 | `ABtools/find_duplicates.py` |
+| `find_duplicates.py` | v0.4 | `ABtools/find_duplicates.py` |
 | `abclient.py` | v0.2 | `ABtools/abclient.py` |
 
 Run any script with `--version` to print its version and file location.
@@ -124,7 +125,7 @@ details.
 `restructure_for_audiobookshelf.py` reorganizes a source collection into Audiobookshelf layout. It reads tags from the audio files first, then `metadata.json` or `book.nfo`, and finally falls back to folder names. Disc folders are flattened and books are moved or copied to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`. Series names and volume numbers are detected with fuzzy matching (e.g. `Book 3`, `#3`, `Volume III`). When run with `--interactive`, the script prompts for missing series info. Metadata matching is handled by `search_and_tag.py`. Track renaming now avoids collisions by staging files with temporary names first.
 
 ## `find_duplicates.py`
-`find_duplicates.py` scans a folder recursively and reports audio files with identical SHA1 hashes. Progress is shown while scanning. Results are also written to `duplicate_log.txt` inside the scanned folder. Use `--version` to show the script version and path.
+`find_duplicates.py` scans a folder recursively and can find duplicates either by computing SHA1 hashes or by matching file names. Progress is shown while scanning. Results are written to `duplicate_log.txt` inside the scanned folder. Use `--version` to show the script version and path. Hash matching now skips hashing files with unique sizes for much faster scans.
 
 
 

--- a/scaffold.md
+++ b/scaffold.md
@@ -63,7 +63,9 @@ Audiobooks/
 
 ### `find_duplicates.py`
 
-- Scans recursively for audio files with identical SHA1 hashes
+- Scans recursively for audio files
+- Can compare files by SHA1 hash or by name
+- Skips hashing files with unique sizes for faster scans
 - Prints groups of duplicate files
 - Writes results to `duplicate_log.txt` in the scanned folder
 - Shows scanning progress
@@ -95,6 +97,6 @@ Audiobooks/
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |
-| `find_duplicates.py` | v0.3 | `ABtools/find_duplicates.py` |
+| `find_duplicates.py` | v0.4 | `ABtools/find_duplicates.py` |
 | `abclient.py` | v0.2 | `ABtools/abclient.py` |
 


### PR DESCRIPTION
## Summary
- improve duplicate search by skipping hash calculation when file size is unique
- allow `find_duplicates.py` to match by name or hash
- document the new option in README and scaffold
- bump find_duplicates version to v0.4 with path updates

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685052d4f31883228d8995c01a879a92