### PR TITLE
Fix tag writing in combobook and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- ABtools/README.md · v1.1 · 2025-08-31 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -45,7 +46,7 @@ pip install -r requirements.txt
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.7 | `ABtools/combobook.py` |
+| `combobook.py` | v1.8 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |
@@ -58,6 +59,8 @@ Run any script with `--version` to print its version and file location.
 `combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files.
 
 It now also collapses folders named like `Book Title (1 of 5)` into a single directory and names each file `Part 01`, `Part 02`, etc.
+
+FFmpeg tag writing previously failed silently; the script now specifies the output file so tags are embedded correctly.
 
 """
 

--- a/combobook.py
+++ b/combobook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/combobook.py  ·  v1.7  ·  2025-09-01
+ABtools/combobook.py  ·  v1.8  ·  2025-08-31
 
 USAGE
 -----
@@ -30,7 +30,7 @@ from typing import List, Optional
 from difflib import SequenceMatcher
 import errno
 
-VERSION = "1.7"
+VERSION = "1.8"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -336,8 +336,13 @@ def write_tags(track:Path, meta:Meta, index:int=0, total:int=0):
         cmd += ["-metadata", f"series-part={meta.seq}"]
     if meta.year: cmd+=["-metadata",f"date={meta.year}"]
     if index: cmd += ["-metadata", f"track={index}/{total or index}"]
-    subprocess.run(cmd,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
-    if tmp.exists(): tmp.replace(track)
+    cmd.append(str(tmp))
+    res = subprocess.run(cmd,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
+    if res.returncode == 0 and tmp.exists():
+        tmp.replace(track)
+    elif tmp.exists():
+        tmp.unlink(missing_ok=True)
+        rprint("[red]✗ failed to write tags[/]")
 
 # ───────────── disc-flattener ────────────────────────────────────────────────
 def flatten(folder: Path, dry: bool):

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,3 +1,4 @@
+<!-- ABtools/scaffold.md · v1.1 · 2025-08-31 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -50,6 +51,7 @@ Audiobooks/
   - Tags them using `search_and_tag.py` logic
   - Creates cleaned-up `Author/Year - Title` folder
   - Moves and renames content
+  - Embeds tags with FFmpeg; fixed missing output file to ensure tags are written
 
 ### `restructure_for_audiobookshelf.py`
 
@@ -93,7 +95,7 @@ Audiobooks/
 
 | Script | Version | Path |
 |-------|---------|------|
-| `combobook.py` | v1.7 | `ABtools/combobook.py` |
+| `combobook.py` | v1.8 | `ABtools/combobook.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |


### PR DESCRIPTION
## Summary
- fix FFmpeg metadata writing by adding output file and error handling
- bump combobook to v1.8 with path-aware version info
- document combobook changes and add version headers to README and scaffold

## Testing
- `PYTHONPATH=. pytest tests/test_abclient.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42eb9bc84832296e0e4894a7bab74