### PR TITLE
Add Tkinter GUI for combobook and update docs

### DIFF
--- a/AbtoolsGui.py
+++ b/AbtoolsGui.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+ABtools/AbtoolsGui.py  ·  v0.1  ·  2025-08-31
+"""
+from __future__ import annotations
+
+import sys
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from pathlib import Path
+import combobook
+
+VERSION = "0.1"
+FILE_PATH = Path(__file__).resolve()
+VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
+
+if "--version" in sys.argv:
+    print(VERSION_INFO % {"prog": Path(sys.argv[0]).name})
+    sys.exit(0)
+
+root = tk.Tk()
+root.title("ABtools GUI")
+
+# --- input fields ---
+source_var = tk.StringVar()
+dest_var = tk.StringVar()
+
+def browse_src():
+    path = filedialog.askdirectory()
+    if path:
+        source_var.set(path)
+
+def browse_dst():
+    path = filedialog.askdirectory()
+    if path:
+        dest_var.set(path)
+
+tk.Label(root, text="Source").grid(row=0, column=0, sticky="e")
+tk.Entry(root, textvariable=source_var, width=40).grid(row=0, column=1, columnspan=2, padx=5, pady=5)
+tk.Button(root, text="Browse", command=browse_src).grid(row=0, column=3, padx=5)
+
+tk.Label(root, text="Destination").grid(row=1, column=0, sticky="e")
+tk.Entry(root, textvariable=dest_var, width=40).grid(row=1, column=1, columnspan=2, padx=5, pady=5)
+tk.Button(root, text="Browse", command=browse_dst).grid(row=1, column=3, padx=5)
+
+# --- options ---
+commit_var = tk.BooleanVar()
+copy_var = tk.BooleanVar()
+yes_var = tk.BooleanVar()
+
+tk.Checkbutton(root, text="Commit", variable=commit_var).grid(row=2, column=0, sticky="w", padx=5)
+tk.Checkbutton(root, text="Copy", variable=copy_var).grid(row=2, column=1, sticky="w", padx=5)
+tk.Checkbutton(root, text="Yes", variable=yes_var).grid(row=2, column=2, sticky="w", padx=5)
+
+def run():
+    src = Path(source_var.get()).expanduser()
+    dst = Path(dest_var.get()).expanduser()
+    if not src.exists():
+        messagebox.showerror("Error", "Source path does not exist")
+        return
+    dst.mkdir(parents=True, exist_ok=True)
+    combobook.AUTO_YES = yes_var.get()
+    try:
+        combobook.main(src, dst, commit_var.get(), yes_var.get(), copy_var.get())
+        messagebox.showinfo("Done", "Processing finished")
+    except Exception as exc:
+        messagebox.showerror("Error", str(exc))
+
+tk.Button(root, text="Run", command=run).grid(row=3, column=0, columnspan=4, pady=10)
+
+if __name__ == "__main__":
+    root.mainloop()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ABtools/README.md · v1.1 · 2025-08-31 -->
+<!-- ABtools/README.md · v1.2 · 2025-08-31 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -46,7 +46,8 @@ pip install -r requirements.txt
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.8 | `ABtools/combobook.py` |
+| `combobook.py` | v1.9 | `ABtools/combobook.py` |
+| `AbtoolsGui.py` | v0.1 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |
@@ -59,6 +60,8 @@ Run any script with `--version` to print its version and file location.
 `combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files.
 
 It now also collapses folders named like `Book Title (1 of 5)` into a single directory and names each file `Part 01`, `Part 02`, etc.
+
+For a simple graphical front-end, use `AbtoolsGui.py`, which provides text fields for source and destination folders and checkboxes for `--commit`, `--copy` and `--yes` options.
 
 FFmpeg tag writing previously failed silently; the script now specifies the output file so tags are embedded correctly.
 
@@ -102,6 +105,9 @@ python combobook.py "source_folder" "library_folder" --commit --copy
 Folders are moved to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`.
 
 Both `combobook.py` and `restructure_for_audiobookshelf.py` can copy books when run with `--copy` alongside `--commit`.
+
+## `AbtoolsGui.py`
+`AbtoolsGui.py` offers a basic Tkinter interface for `combobook.py`. It provides text fields for selecting the source and library folders and checkboxes matching the `--commit`, `--copy` and `--yes` command-line options.
 
 ## `search_and_tag.py`
 `search_and_tag.py` tags or strips audiobook files. It queries Audible,

--- a/combobook.py
+++ b/combobook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/combobook.py  ·  v1.8  ·  2025-08-31
+ABtools/combobook.py  ·  v1.9  ·  2025-08-31
 
 USAGE
 -----
@@ -30,7 +30,7 @@ from typing import List, Optional
 from difflib import SequenceMatcher
 import errno
 
-VERSION = "1.8"
+VERSION = "1.9"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,4 +1,4 @@
-<!-- ABtools/scaffold.md · v1.1 · 2025-08-31 -->
+<!-- ABtools/scaffold.md · v1.2 · 2025-08-31 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -9,6 +9,7 @@ Audiobooks/
 ├── search_and_tag.py       # Tags files using metadata providers
 ├── flatten_discs.py        # Merges "Disc" folders into one
 ├── combobook.py            # Combines tagging and restructuring
+├── AbtoolsGui.py           # Tkinter GUI for combobook
 ├── restructure_for_audiobookshelf.py  # Reorganizes folders into Audiobookshelf layout
 ├── find_duplicates.py      # Reports duplicate audio files
 ├── metadata.json           # Optional: sample metadata format
@@ -51,7 +52,13 @@ Audiobooks/
   - Tags them using `search_and_tag.py` logic
   - Creates cleaned-up `Author/Year - Title` folder
   - Moves and renames content
-  - Embeds tags with FFmpeg; fixed missing output file to ensure tags are written
+- Embeds tags with FFmpeg; fixed missing output file to ensure tags are written
+
+### `AbtoolsGui.py`
+
+- Simple Tkinter GUI front-end for `combobook.py`
+- Text fields for source and library folders
+- Checkboxes for `--commit`, `--copy` and `--yes`
 
 ### `restructure_for_audiobookshelf.py`
 
@@ -95,7 +102,8 @@ Audiobooks/
 
 | Script | Version | Path |
 |-------|---------|------|
-| `combobook.py` | v1.8 | `ABtools/combobook.py` |
+| `combobook.py` | v1.9 | `ABtools/combobook.py` |
+| `AbtoolsGui.py` | v0.1 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |


### PR DESCRIPTION
## Summary
- add AbtoolsGui.py: a Tkinter frontend exposing text fields for source and destination and checkboxes for commit/copy/yes options
- bump combobook.py to v1.9 for GUI support
- document new GUI in README and scaffold

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b432e1b68083229a7aeb4ba6563ed6