### PR TITLE
Handle unmatched audiobooks in combobook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ABtools/README.md · v1.2 · 2025-08-31 -->
+<!-- ABtools/README.md · v1.3 · 2025-08-31 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -46,7 +46,7 @@ pip install -r requirements.txt
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.9 | `ABtools/combobook.py` |
+| `combobook.py` | v1.10 | `ABtools/combobook.py` |
 | `AbtoolsGui.py` | v0.1 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
@@ -57,7 +57,7 @@ pip install -r requirements.txt
 Run any script with `--version` to print its version and file location.
 
 ## `combobook.py`
-`combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files.
+`combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files. When no match is found, the folder is moved into an `_unmatched` directory inside your library for later review.
 
 It now also collapses folders named like `Book Title (1 of 5)` into a single directory and names each file `Part 01`, `Part 02`, etc.
 

--- a/combobook.py
+++ b/combobook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/combobook.py  ·  v1.9  ·  2025-08-31
+ABtools/combobook.py  ·  v1.10  ·  2025-08-31
 
 USAGE
 -----
@@ -30,7 +30,7 @@ from typing import List, Optional
 from difflib import SequenceMatcher
 import errno
 
-VERSION = "1.9"
+VERSION = "1.10"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -40,6 +40,7 @@ FLATTEN_DISCS = True
 RENAME_TRACKS = False          # Track 001.*, Track 002.* …
 WRITE_TAGS    = True           # needs ffmpeg on PATH
 AUTO_YES      = False          # --yes overrides per-run
+UNMATCHED_DIR = "_unmatched"   # destination for folders with no metadata match
 
 # “disc / disk / cd / part” + optional ()[]{}
 DISC_RX = re.compile(
@@ -477,8 +478,24 @@ def process(folder: Path, lib: Path, dry: bool, yes: bool, copy: bool, summary: 
         # Prompt the user (or auto‐yes) for a match
         hit = choose_meta(guess)
         if not hit:
-            rprint("[yellow]• skip (no tags / no match):[/] ", folder.relative_to(SRC))
-            summary["skip"] += 1
+            rprint("[yellow]• no metadata match:[/]", folder.relative_to(SRC))
+            summary["unmatched"] += 1
+            dest = lib / UNMATCHED_DIR / slug(folder.name)
+            action = 'cp' if copy else 'mv'
+            rprint(f"{action if not dry else '↪'} {folder.relative_to(SRC)} → {dest.relative_to(lib)}")
+            if dry:
+                summary["would_move"] += 1
+                if FLATTEN_DISCS:
+                    flatten(folder, True)
+                if RENAME_TRACKS and not FLATTEN_DISCS:
+                    rename_tracks(folder)
+                return
+            safe_move(folder, dest, copy=copy)
+            if FLATTEN_DISCS:
+                flatten(dest, False)
+            if RENAME_TRACKS and not FLATTEN_DISCS:
+                rename_tracks(dest)
+            summary["moved"] += 1
             return
 
         # Write tags to all tracks in this folder
@@ -534,7 +551,7 @@ def main(src:Path, lib:Path, commit:bool, yes:bool, copy: bool):
     rprint(f"  {action_word:12}: {summary['moved']}")
     if not commit:
         rprint(f"  would_move   : {summary['would_move']}")
-    for k in ("exists","skip"):
+    for k in ("exists","skip","unmatched"):
         rprint(f"  {k:12}: {summary[k]}")
 
 if __name__=="__main__":

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,4 +1,4 @@
-<!-- ABtools/scaffold.md · v1.2 · 2025-08-31 -->
+<!-- ABtools/scaffold.md · v1.3 · 2025-08-31 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -52,7 +52,8 @@ Audiobooks/
   - Tags them using `search_and_tag.py` logic
   - Creates cleaned-up `Author/Year - Title` folder
   - Moves and renames content
-- Embeds tags with FFmpeg; fixed missing output file to ensure tags are written
+  - Unmatched folders are moved into an `_unmatched` directory for manual review
+  - Embeds tags with FFmpeg; fixed missing output file to ensure tags are written
 
 ### `AbtoolsGui.py`
 
@@ -102,7 +103,7 @@ Audiobooks/
 
 | Script | Version | Path |
 |-------|---------|------|
-| `combobook.py` | v1.9 | `ABtools/combobook.py` |
+| `combobook.py` | v1.10 | `ABtools/combobook.py` |
 | `AbtoolsGui.py` | v0.1 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |


### PR DESCRIPTION
## Summary
- move folders with no metadata match into an `_unmatched` directory
- document unmatched handling and bump `combobook.py` to v1.10

## Testing
- `python -m py_compile combobook.py`
- `PYTHONPATH=. pytest tests/test_abclient.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43797c45c83228b94e345ceb4f0ef