### PR TITLE
Handle spaces in source paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 - Detects series and volume numbers with fuzzy matching
   and prompts for confirmation when run with `--interactive`
 - Each script reports its version and location with `--version`
+- `combobook.py` and `restructure_for_audiobookshelf.py` accept paths with spaces without quoting
 - Experimental features are toggled via `~/.abclient.json` using `AbClient`
 - Prints the score from each metadata provider during tagging
 - `find_duplicates.py` shows progress while scanning and can compare
@@ -46,10 +47,10 @@ pip install -r requirements.txt
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.10 | `ABtools/combobook.py` |
+| `combobook.py` | v1.11 | `ABtools/combobook.py` |
 | `AbtoolsGui.py` | v0.2 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
+| `restructure_for_audiobookshelf.py` | v4.9 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |
 | `find_duplicates.py` | v0.4 | `ABtools/find_duplicates.py` |
 | `abclient.py` | v0.2 | `ABtools/abclient.py` |

--- a/combobook.py
+++ b/combobook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/combobook.py  ·  v1.10  ·  2025-08-31
+ABtools/combobook.py  ·  v1.11  ·  2025-09-01
 
 USAGE
 -----
@@ -30,7 +30,7 @@ from typing import List, Optional
 from difflib import SequenceMatcher
 import errno
 
-VERSION = "1.10"
+VERSION = "1.11"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -564,15 +564,32 @@ if __name__=="__main__":
               --commit    actually move / write tags (omit for preview)
               --yes       auto-accept every metadata match
             """))
-    ap.add_argument("source_root", type=Path)
-    ap.add_argument("library_root", type=Path)
+    ap.add_argument("paths", nargs="+", metavar=("source_root","library_root"))
     ap.add_argument("--commit", action="store_true")
     ap.add_argument("--yes",    action="store_true")
     ap.add_argument("--copy",   action="store_true", help="Copy instead of move when used with --commit")
     ap.add_argument("--version", action="version", version=VERSION_INFO)
     args=ap.parse_args()
-    SRC=args.source_root.resolve(); LIB=args.library_root.resolve()
-    if not SRC.is_dir(): sys.exit("source_root not found")
+
+    if len(args.paths) < 2:
+        ap.error("source_root and library_root required")
+
+    raw = args.paths
+    src = None
+    for i in range(1, len(raw)):
+        cand = Path(" ".join(raw[:i])).expanduser()
+        if cand.exists():
+            src = cand
+            dst = Path(" ".join(raw[i:])).expanduser()
+            break
+    if src is None:
+        src = Path(raw[0]).expanduser()
+        dst = Path(" ".join(raw[1:])).expanduser()
+
+    SRC = src.resolve()
+    LIB = dst.resolve()
+    if not SRC.is_dir():
+        sys.exit(f"source_root not found: {SRC}")
     LIB.mkdir(exist_ok=True, parents=True)
     AUTO_YES=args.yes
     main(SRC,LIB,args.commit,args.yes,args.copy)

--- a/restructure_for_audiobookshelf.py
+++ b/restructure_for_audiobookshelf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/restructure_for_audiobookshelf.py – v4.8  (2025-09-01)
+ABtools/restructure_for_audiobookshelf.py – v4.9  (2025-09-01)
 Use restructure_for_audiobookshelf.py "Source folder" "Destination folder" --commit 
 • Recursively scans source_root; every directory that *contains* audio but whose
   sub-directories don’t is treated as one “book”.
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import List, Optional
 import xml.etree.ElementTree as ET
 
-VERSION = "4.8"
+VERSION = "4.9"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -491,8 +491,7 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser(
         description="Recursively tidy audiobook folders for Audiobookshelf."
     )
-    ap.add_argument("source_root", type=Path, help="Folder to scan recursively")
-    ap.add_argument("library_root", type=Path, help="Audiobookshelf library root")
+    ap.add_argument("paths", nargs="+", metavar=("source_root", "library_root"))
     ap.add_argument(
         "--commit",
         action="store_true",
@@ -510,5 +509,20 @@ if __name__ == "__main__":
     )
     ap.add_argument("--version", action="version", version=VERSION_INFO)
     args = ap.parse_args()
-    main(args.source_root, args.library_root, args.commit, args.copy,
-         args.interactive)
+
+    if len(args.paths) < 2:
+        ap.error("source_root and library_root required")
+
+    raw = args.paths
+    src = None
+    for i in range(1, len(raw)):
+        cand = Path(" ".join(raw[:i])).expanduser()
+        if cand.exists():
+            src = cand
+            dst = Path(" ".join(raw[i:])).expanduser()
+            break
+    if src is None:
+        src = Path(raw[0]).expanduser()
+        dst = Path(" ".join(raw[1:])).expanduser()
+
+    main(src, dst, args.commit, args.copy, args.interactive)

--- a/scaffold.md
+++ b/scaffold.md
@@ -54,6 +54,7 @@ Audiobooks/
   - Moves and renames content
   - Unmatched folders are moved into an `_unmatched` directory for manual review
   - Embeds tags with FFmpeg; fixed missing output file to ensure tags are written
+  - Accepts source paths with spaces without needing quotes
 
 ### `AbtoolsGui.py`
 
@@ -71,6 +72,7 @@ Audiobooks/
 - Renames tracks safely to avoid name collisions
 - Detects fuzzy series numbering ("Book 2", "#2", "Volume II")
 - `--interactive` prompts for series info when unclear
+- Handles source folders with spaces without quoting
 
 ### `find_duplicates.py`
 
@@ -104,10 +106,10 @@ Audiobooks/
 
 | Script | Version | Path |
 |-------|---------|------|
-| `combobook.py` | v1.10 | `ABtools/combobook.py` |
+| `combobook.py` | v1.11 | `ABtools/combobook.py` |
 | `AbtoolsGui.py` | v0.2 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v4.8 | `ABtools/restructure_for_audiobookshelf.py` |
+| `restructure_for_audiobookshelf.py` | v4.9 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |
 | `find_duplicates.py` | v0.4 | `ABtools/find_duplicates.py` |
 | `abclient.py` | v0.2 | `ABtools/abclient.py` |


### PR DESCRIPTION
## Summary
- support unquoted paths containing spaces in `combobook.py`
- support unquoted paths containing spaces in `restructure_for_audiobookshelf.py`
- document new path handling and bump script versions

## Testing
- `python -m py_compile combobook.py restructure_for_audiobookshelf.py`
- `PYTHONPATH=. pytest tests/test_abclient.py`


------
https://chatgpt.com/codex/tasks/task_e_68b46e78b69883229954b3e3759ad731