### PR TITLE
Fix undefined SRC in combobook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ABtools/README.md · v1.4 · 2025-09-01 -->
+<!-- ABtools/README.md · v1.5 · 2025-09-01 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -47,7 +47,7 @@ pip install -r requirements.txt
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.11 | `ABtools/combobook.py` |
+| `combobook.py` | v1.12 | `ABtools/combobook.py` |
 | `AbtoolsGui.py` | v0.2 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.9 | `ABtools/restructure_for_audiobookshelf.py` |
@@ -61,6 +61,8 @@ Run any script with `--version` to print its version and file location.
 `combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files. When no match is found, the folder is moved into an `_unmatched` directory inside your library for later review.
 
 It now also collapses folders named like `Book Title (1 of 5)` into a single directory and names each file `Part 01`, `Part 02`, etc.
+
+The source path is now passed explicitly, avoiding `NameError: SRC is not defined` when the script is imported by other modules or run via the GUI.
 
 For a simple graphical front-end, use `AbtoolsGui.py`, which provides text fields for source and destination folders, checkboxes for `--commit`, `--copy` and `--yes` options, and a live output pane.
 

--- a/combobook.py
+++ b/combobook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/combobook.py  ·  v1.11  ·  2025-09-01
+ABtools/combobook.py  ·  v1.12  ·  2025-09-01
 
 USAGE
 -----
@@ -30,7 +30,7 @@ from typing import List, Optional
 from difflib import SequenceMatcher
 import errno
 
-VERSION = "1.11"
+VERSION = "1.12"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -451,7 +451,7 @@ def dest_path(lib: Path, meta: Meta) -> Path:
     return dest
 
 # ───────────── process one folder ────────────────────────────────────────────
-def process(folder: Path, lib: Path, dry: bool, yes: bool, copy: bool, summary: dict):
+def process(folder: Path, src: Path, lib: Path, dry: bool, yes: bool, copy: bool, summary: dict):
     summary["total"] += 1
 
     # 1) Gather all audio files in this folder
@@ -478,11 +478,11 @@ def process(folder: Path, lib: Path, dry: bool, yes: bool, copy: bool, summary: 
         # Prompt the user (or auto‐yes) for a match
         hit = choose_meta(guess)
         if not hit:
-            rprint("[yellow]• no metadata match:[/]", folder.relative_to(SRC))
+            rprint("[yellow]• no metadata match:[/]", folder.relative_to(src))
             summary["unmatched"] += 1
             dest = lib / UNMATCHED_DIR / slug(folder.name)
             action = 'cp' if copy else 'mv'
-            rprint(f"{action if not dry else '↪'} {folder.relative_to(SRC)} → {dest.relative_to(lib)}")
+            rprint(f"{action if not dry else '↪'} {folder.relative_to(src)} → {dest.relative_to(lib)}")
             if dry:
                 summary["would_move"] += 1
                 if FLATTEN_DISCS:
@@ -527,7 +527,7 @@ def process(folder: Path, lib: Path, dry: bool, yes: bool, copy: bool, summary: 
             return
 
     action = 'cp' if copy else 'mv'
-    rprint(f"{action if not dry else '↪'} {folder.relative_to(SRC)} → {dest.relative_to(lib)}")
+    rprint(f"{action if not dry else '↪'} {folder.relative_to(src)} → {dest.relative_to(lib)}")
     if dry:
         summary["would_move"] += 1
         return
@@ -544,7 +544,7 @@ def process(folder: Path, lib: Path, dry: bool, yes: bool, copy: bool, summary: 
 def main(src:Path, lib:Path, commit:bool, yes:bool, copy: bool):
     summary=defaultdict(int)
     for leaf in leaf_dirs(src):
-        process(leaf,lib,dry=not commit,yes=yes,copy=copy,summary=summary)
+        process(leaf, src, lib, dry=not commit, yes=yes, copy=copy, summary=summary)
     rprint("\n[bold]summary[/]")
     action_word = "copied" if copy else "moved"
     rprint(f"  total        : {summary['total']}")
@@ -586,10 +586,10 @@ if __name__=="__main__":
         src = Path(raw[0]).expanduser()
         dst = Path(" ".join(raw[1:])).expanduser()
 
-    SRC = src.resolve()
-    LIB = dst.resolve()
-    if not SRC.is_dir():
-        sys.exit(f"source_root not found: {SRC}")
-    LIB.mkdir(exist_ok=True, parents=True)
-    AUTO_YES=args.yes
-    main(SRC,LIB,args.commit,args.yes,args.copy)
+    src = src.resolve()
+    lib = dst.resolve()
+    if not src.is_dir():
+        sys.exit(f"source_root not found: {src}")
+    lib.mkdir(exist_ok=True, parents=True)
+    AUTO_YES = args.yes
+    main(src, lib, args.commit, args.yes, args.copy)

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,4 +1,4 @@
-<!-- ABtools/scaffold.md · v1.4 · 2025-09-01 -->
+<!-- ABtools/scaffold.md · v1.5 · 2025-09-01 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -52,9 +52,10 @@ Audiobooks/
   - Tags them using `search_and_tag.py` logic
   - Creates cleaned-up `Author/Year - Title` folder
   - Moves and renames content
-  - Unmatched folders are moved into an `_unmatched` directory for manual review
-  - Embeds tags with FFmpeg; fixed missing output file to ensure tags are written
-  - Accepts source paths with spaces without needing quotes
+    - Unmatched folders are moved into an `_unmatched` directory for manual review
+    - Embeds tags with FFmpeg; fixed missing output file to ensure tags are written
+    - Accepts source paths with spaces without needing quotes
+    - Passes the source path explicitly to avoid `NameError: SRC is not defined` when imported elsewhere
 
 ### `AbtoolsGui.py`
 
@@ -106,7 +107,7 @@ Audiobooks/
 
 | Script | Version | Path |
 |-------|---------|------|
-| `combobook.py` | v1.11 | `ABtools/combobook.py` |
+| `combobook.py` | v1.12 | `ABtools/combobook.py` |
 | `AbtoolsGui.py` | v0.2 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.9 | `ABtools/restructure_for_audiobookshelf.py` |


### PR DESCRIPTION
## Summary
- pass source path into `process` to avoid NameError when importing `combobook`
- document new behavior and bump version numbers

## Testing
- `python -m py_compile combobook.py`
- `python -m py_compile AbtoolsGui.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49238ed98832293496ced5752e636