### PR TITLE
feat(gui): add tag-only mode

### DIFF
--- a/AbtoolsGui.py
+++ b/AbtoolsGui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/AbtoolsGui.py  ·  v0.2  ·  2025-09-01
+ABtools/AbtoolsGui.py  ·  v0.4  ·  2025-09-01
 """
 from __future__ import annotations
 
@@ -12,8 +12,9 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 from pathlib import Path
 import combobook
+import search_and_tag
 
-VERSION = "0.2"
+VERSION = "0.4"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -23,6 +24,9 @@ if "--version" in sys.argv:
 
 root = tk.Tk()
 root.title("ABtools GUI")
+for i in range(4):
+    root.grid_columnconfigure(i, weight=1)
+root.grid_rowconfigure(4, weight=1)
 
 # --- input fields ---
 source_var = tk.StringVar()
@@ -58,8 +62,20 @@ tk.Checkbutton(root, text="Yes", variable=yes_var).grid(row=2, column=2, sticky=
 # --- output ---
 output_queue: queue.Queue[tuple[str, str]] = queue.Queue()
 
-output_text = tk.Text(root, height=15, width=60, state="disabled")
-output_text.grid(row=4, column=0, columnspan=4, padx=5, pady=5)
+output_frame = tk.Frame(root)
+output_frame.grid(row=4, column=0, columnspan=4, sticky="nsew", padx=5, pady=5)
+output_frame.grid_rowconfigure(0, weight=1)
+output_frame.grid_columnconfigure(0, weight=1)
+
+output_text = tk.Text(output_frame, height=15, width=60, wrap="none", state="disabled")
+output_text.grid(row=0, column=0, sticky="nsew")
+
+y_scroll = tk.Scrollbar(output_frame, orient="vertical", command=output_text.yview)
+y_scroll.grid(row=0, column=1, sticky="ns")
+x_scroll = tk.Scrollbar(output_frame, orient="horizontal", command=output_text.xview)
+x_scroll.grid(row=1, column=0, sticky="ew")
+
+output_text.configure(yscrollcommand=y_scroll.set, xscrollcommand=x_scroll.set)
 
 def append_output(text: str) -> None:
     output_text.configure(state="normal")
@@ -120,7 +136,42 @@ def run() -> None:
 
     threading.Thread(target=worker, daemon=True).start()
 
-tk.Button(root, text="Run", command=run).grid(row=3, column=0, columnspan=4, pady=10)
+
+def tag_only() -> None:
+    src = Path(source_var.get()).expanduser()
+    if not src.exists():
+        messagebox.showerror("Error", "Source path does not exist")
+        return
+
+    output_text.configure(state="normal")
+    output_text.delete("1.0", tk.END)
+    output_text.configure(state="disabled")
+
+    def worker() -> None:
+        try:
+            with redirect_stdout(QueueWriter(output_queue)), redirect_stderr(
+                QueueWriter(output_queue)
+            ):
+                args = [str(src), "--recurse"]
+                if commit_var.get():
+                    args.append("--commit")
+                if yes_var.get():
+                    args.append("--yes")
+                old_argv = sys.argv
+                sys.argv = ["search_and_tag.py"] + args
+                try:
+                    search_and_tag.main()
+                finally:
+                    sys.argv = old_argv
+            output_queue.put(("status", "done"))
+        except Exception as exc:  # pragma: no cover - handled via GUI
+            output_queue.put(("status", f"error:{exc}"))
+
+    threading.Thread(target=worker, daemon=True).start()
+
+
+tk.Button(root, text="Run", command=run).grid(row=3, column=0, columnspan=2, pady=10)
+tk.Button(root, text="Tag Only", command=tag_only).grid(row=3, column=2, columnspan=2, pady=10)
 
 if __name__ == "__main__":
     poll_queue()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ABtools/README.md · v1.5 · 2025-09-01 -->
+<!-- ABtools/README.md · v1.7 · 2025-09-01 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -48,7 +48,7 @@ pip install -r requirements.txt
 |-------|---------|------|
 
 | `combobook.py` | v1.12 | `ABtools/combobook.py` |
-| `AbtoolsGui.py` | v0.2 | `ABtools/AbtoolsGui.py` |
+| `AbtoolsGui.py` | v0.4 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.9 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |
@@ -64,7 +64,7 @@ It now also collapses folders named like `Book Title (1 of 5)` into a single dir
 
 The source path is now passed explicitly, avoiding `NameError: SRC is not defined` when the script is imported by other modules or run via the GUI.
 
-For a simple graphical front-end, use `AbtoolsGui.py`, which provides text fields for source and destination folders, checkboxes for `--commit`, `--copy` and `--yes` options, and a live output pane.
+For a simple graphical front-end, use `AbtoolsGui.py`, which provides text fields for source and destination folders, checkboxes for `--commit`, `--copy` and `--yes` options, and a resizable output pane with scroll bars. It also includes a "Tag Only" button that runs `search_and_tag.py` without moving files.
 
 FFmpeg tag writing previously failed silently; the script now specifies the output file so tags are embedded correctly.
 
@@ -110,7 +110,7 @@ Folders are moved to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`
 Both `combobook.py` and `restructure_for_audiobookshelf.py` can copy books when run with `--copy` alongside `--commit`.
 
 ## `AbtoolsGui.py`
-`AbtoolsGui.py` offers a basic Tkinter interface for `combobook.py`. It provides text fields for selecting the source and library folders, checkboxes matching the `--commit`, `--copy` and `--yes` command-line options, and shows live `combobook` output in a scrolling pane.
+`AbtoolsGui.py` offers a basic Tkinter interface for `combobook.py`. It provides text fields for selecting the source and library folders, checkboxes matching the `--commit`, `--copy` and `--yes` command-line options, and shows live `combobook` output in a resizable pane with scroll bars. A separate "Tag Only" button uses `search_and_tag.py` to tag files without moving them.
 
 ## `search_and_tag.py`
 `search_and_tag.py` tags or strips audiobook files. It queries Audible,

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,4 +1,4 @@
-<!-- ABtools/scaffold.md · v1.5 · 2025-09-01 -->
+<!-- ABtools/scaffold.md · v1.7 · 2025-09-01 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -9,7 +9,7 @@ Audiobooks/
 ├── search_and_tag.py       # Tags files using metadata providers
 ├── flatten_discs.py        # Merges "Disc" folders into one
 ├── combobook.py            # Combines tagging and restructuring
-├── AbtoolsGui.py           # Tkinter GUI for combobook with live output
+├── AbtoolsGui.py           # Tkinter GUI for combobook with resizable output and tag-only mode
 ├── restructure_for_audiobookshelf.py  # Reorganizes folders into Audiobookshelf layout
 ├── find_duplicates.py      # Reports duplicate audio files
 ├── metadata.json           # Optional: sample metadata format
@@ -62,7 +62,8 @@ Audiobooks/
 - Simple Tkinter GUI front-end for `combobook.py`
 - Text fields for source and library folders
 - Checkboxes for `--commit`, `--copy` and `--yes`
-- Live output pane showing `combobook` progress
+- Resizable output pane with scroll bars showing `combobook` progress
+- "Tag Only" button that runs `search_and_tag.py` without moving files
 
 ### `restructure_for_audiobookshelf.py`
 
@@ -108,7 +109,7 @@ Audiobooks/
 | Script | Version | Path |
 |-------|---------|------|
 | `combobook.py` | v1.12 | `ABtools/combobook.py` |
-| `AbtoolsGui.py` | v0.2 | `ABtools/AbtoolsGui.py` |
+| `AbtoolsGui.py` | v0.4 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.9 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |


### PR DESCRIPTION
## Summary
- add Tag Only button to AbtoolsGui using search_and_tag
- document GUI tag-only mode in README and scaffold
- make GUI output pane resizable with scroll bars and update docs

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc89f2d8a483228885ce61785d8bd5