### PR TITLE
Improve search_and_tag matching with author weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ABtools/README.md · v1.6 · 2025-09-01 -->
+<!-- ABtools/README.md · v1.7 · 2025-09-01 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -15,6 +15,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 - Provides preview and logging
 - Optionally prompts for confirmation or proceeds automatically
 - Fetches metadata in parallel for faster tagging
+- Ranks matches using both title and author similarity for better accuracy
 - Preserves part numbers like `(1 of 6)` when reorganizing files
 - Adds track numbers so multi-part books play in order
 - Detects series and volume numbers with fuzzy matching
@@ -51,7 +52,7 @@ pip install -r requirements.txt
 | `AbtoolsGui.py` | v0.3 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.9 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.16 | `ABtools/search_and_tag.py` |
 | `find_duplicates.py` | v0.4 | `ABtools/find_duplicates.py` |
 | `abclient.py` | v0.2 | `ABtools/abclient.py` |
 
@@ -70,14 +71,14 @@ FFmpeg tag writing previously failed silently; the script now specifies the outp
 
 """
 
-Tag (or strip) audiobook files using multiple metadata providers.
+  Tag (or strip) audiobook files using multiple metadata providers.
 
-The script queries Audible, Open Library and Google Books, ranks the
-results using fuzzy title matching and automatically tags files with the
-best match. Low scoring hits will prompt for confirmation unless you
-run with ``--yes``. When prompted, the default answer is "No" so low
-confidence matches won't be accepted accidentally. Log files are written
-next to the chosen root as ``tag_log.txt`` and ``review_log.txt``.
+  The script queries Audible, Open Library and Google Books, ranks the
+  results using fuzzy title and author matching and automatically tags
+  files with the best match. Low scoring hits will prompt for confirmation
+  unless you run with ``--yes``. When prompted, the default answer is "No" so low
+  confidence matches won't be accepted accidentally. Log files are written
+  next to the chosen root as ``tag_log.txt`` and ``review_log.txt``.
 
 
 examples
@@ -114,7 +115,8 @@ Both `combobook.py` and `restructure_for_audiobookshelf.py` can copy books when 
 
 ## `search_and_tag.py`
 `search_and_tag.py` tags or strips audiobook files. It queries Audible,
-Goodreads (optional), Open Library and Google Books. The score from each
+Goodreads (optional), Open Library and Google Books. Results are ranked
+using both title and author similarity, and the score from each
 provider is printed so you can see which source matched best. Audible is
 queried first when enabled via `abclient.json`. Matches with a low score
 will ask for confirmation unless you pass `--yes`. Use `--no` to

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,4 +1,4 @@
-<!-- ABtools/scaffold.md · v1.6 · 2025-09-01 -->
+<!-- ABtools/scaffold.md · v1.7 · 2025-09-01 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -33,11 +33,12 @@ Audiobooks/
   - `metadata.json`
   - `book.nfo`
   - `--debug` prints tracebacks on errors
-- `--no` auto-declines metadata suggestions
-- fetches metadata in parallel for faster processing
-- `--version` prints the script version and file path
-- Experimental switches stored in `~/.abclient.json` (used by `AbClient`)
-- Prints scores from all metadata providers
+  - `--no` auto-declines metadata suggestions
+  - fetches metadata in parallel for faster processing
+  - ranks matches using title and author similarity
+  - `--version` prints the script version and file path
+  - Experimental switches stored in `~/.abclient.json` (used by `AbClient`)
+  - Prints scores from all metadata providers
 
 ### `flatten_discs.py`
 
@@ -112,7 +113,7 @@ Audiobooks/
 | `AbtoolsGui.py` | v0.3 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v4.9 | `ABtools/restructure_for_audiobookshelf.py` |
-| `search_and_tag.py` | v2.15 | `ABtools/search_and_tag.py` |
+| `search_and_tag.py` | v2.16 | `ABtools/search_and_tag.py` |
 | `find_duplicates.py` | v0.4 | `ABtools/find_duplicates.py` |
 | `abclient.py` | v0.2 | `ABtools/abclient.py` |
 

--- a/search_and_tag.py
+++ b/search_and_tag.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-ABtools/search_and_tag.py – v2.15  (2025-09-01)
+ABtools/search_and_tag.py – v2.16  (2025-09-01)
 Tag (or strip) audiobook files using multiple metadata providers.
 
     The script queries Audible, Open Library and Google Books, ranks the
-    results using fuzzy title matching and automatically tags files with the
-    best match. Low scoring hits will prompt for confirmation unless you
+    results using fuzzy title *and author* matching and automatically tags
+    files with the best match. Low scoring hits will prompt for confirmation unless you
     run with ``--yes``. Use ``--no`` to automatically decline low-scoring
     matches. When prompted, the default answer is "No" so low confidence
     matches won't be accepted accidentally. Log files are written
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Optional, Tuple, List
 from abclient import AbClient
 
-VERSION = "2.15"
+VERSION = "2.16"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -219,7 +219,14 @@ def best_match(author: Optional[str], title: str, client: AbClient = AB) -> tupl
 
     def add_result(name: str, meta: Optional[dict]):
         if meta and meta.get("title"):
-            score = fuzz.token_set_ratio(title.lower(), meta["title"].lower())
+            title_score = fuzz.token_set_ratio(title.lower(), meta["title"].lower())
+            author_score = 0
+            if author and meta.get("authors"):
+                author_score = max(
+                    fuzz.token_set_ratio(author.lower(), a.lower())
+                    for a in meta["authors"]
+                )
+            score = int(title_score * 0.7 + author_score * 0.3)
             meta["source"] = name
             pair = (score, meta)
             candidates.append(pair)


### PR DESCRIPTION
## Summary
- weight metadata matches by both title and author for more accurate tagging
- document enhanced ranking in README and scaffold

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc925753888322a648f27bcd5e26ba