### PR TITLE
Validate plan file path in GUI

### DIFF
--- a/AbtoolsGui.py
+++ b/AbtoolsGui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/AbtoolsGui.py  ·  v0.6  ·  2025-09-01
+ABtools/AbtoolsGui.py  ·  v0.7  ·  2025-09-01
 """
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from pathlib import Path
 from types import SimpleNamespace
 import combobook, search_and_tag, find_duplicates
 
-VERSION = "0.6"
+VERSION = "0.7"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -271,13 +271,14 @@ def find_dupes() -> None:
 def make_plan() -> None:
     src = Path(source_var.get()).expanduser()
     dst = Path(dest_var.get()).expanduser()
-    plan_path = Path(plan_var.get()).expanduser()
+    plan_str = plan_var.get().strip()
     if not src.exists():
         messagebox.showerror("Error", "Source path does not exist")
         return
-    if not plan_path:
+    if not plan_str:
         messagebox.showerror("Error", "Plan path is required")
         return
+    plan_path = Path(plan_str).expanduser()
     dst.mkdir(parents=True, exist_ok=True)
 
     output_text.configure(state="normal")
@@ -305,7 +306,11 @@ def make_plan() -> None:
 
 
 def apply_plan() -> None:
-    plan_path = Path(plan_var.get()).expanduser()
+    plan_str = plan_var.get().strip()
+    if not plan_str:
+        messagebox.showerror("Error", "Plan path is required")
+        return
+    plan_path = Path(plan_str).expanduser()
     if not plan_path.exists():
         messagebox.showerror("Error", "Plan file not found")
         return

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ABtools/README.md · v2.1 · 2025-09-01 -->
+<!-- ABtools/README.md · v2.2 · 2025-09-01 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -29,6 +29,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 - GUI front-end displays a progress bar with estimated time
 - GUI front-end can run `find_duplicates.py` to scan source and destination for duplicate audio files
 - Planning mode writes a JSON plan that can be reviewed before execution
+- GUI front-end checks that a plan file path is selected before generating or applying a plan
 - Transactions are logged and can be rolled back with `--undo-last`
 - Duplicate catalog prevents importing the same book twice
 
@@ -54,7 +55,7 @@ pip install -r requirements.txt
 |-------|---------|------|
 
 | `combobook.py` | v1.13 | `ABtools/combobook.py` |
-| `AbtoolsGui.py` | v0.6 | `ABtools/AbtoolsGui.py` |
+| `AbtoolsGui.py` | v0.7 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v5.0 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.16 | `ABtools/search_and_tag.py` |
@@ -120,6 +121,7 @@ Both `combobook.py` and `restructure_for_audiobookshelf.py` can copy books when 
 
 ## `AbtoolsGui.py`
 `AbtoolsGui.py` offers a basic Tkinter interface for `combobook.py`. It provides text fields for selecting the source and library folders, checkboxes matching the `--commit`, `--copy` and `--yes` command-line options, and shows live `combobook` output in a scrolling pane. A progress bar displays overall progress with an estimated time remaining. Beyond the "Tag Only" and "Find Duplicates" helpers, the GUI now exposes buttons to generate restructure plans, apply them atomically, and undo the most recent transaction.
+It validates that a plan file path is chosen before generating or applying a plan to avoid permission errors.
 
 ## `search_and_tag.py`
 `search_and_tag.py` tags or strips audiobook files. It queries Audible,

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,4 +1,4 @@
-<!-- ABtools/scaffold.md · v1.4 · 2025-09-01 -->
+<!-- ABtools/scaffold.md · v1.5 · 2025-09-01 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -115,7 +115,7 @@ Audiobooks/
 | Script | Version | Path |
 |-------|---------|------|
 | `combobook.py` | v1.13 | `ABtools/combobook.py` |
-| `AbtoolsGui.py` | v0.6 | `ABtools/AbtoolsGui.py` |
+| `AbtoolsGui.py` | v0.7 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v5.0 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.16 | `ABtools/search_and_tag.py` |


### PR DESCRIPTION
## Summary
- Ensure AbtoolsGui verifies a plan file path is specified before generating or applying plans
- Bump AbtoolsGui to v0.7 and update README and scaffold tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd5ed3be288322b3110129b1760de6