### PR TITLE
Keep GUI responsive during large scans

### DIFF
--- a/AbtoolsGui.py
+++ b/AbtoolsGui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/AbtoolsGui.py  ·  v0.7  ·  2025-09-01
+ABtools/AbtoolsGui.py  ·  v0.8  ·  2025-09-01
 """
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from pathlib import Path
 from types import SimpleNamespace
 import combobook, search_and_tag, find_duplicates
 
-VERSION = "0.7"
+VERSION = "0.8"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -95,7 +95,10 @@ class QueueWriter:
         pass
 
 def poll_queue() -> None:
-    while True:
+    # Process a limited number of queued messages per tick so the Tk event
+    # loop stays responsive even when a worker thread floods the queue with
+    # progress updates (e.g. during a large duplicate scan).
+    for _ in range(100):
         try:
             typ, msg = output_queue.get_nowait()
         except queue.Empty:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ABtools/README.md · v2.2 · 2025-09-01 -->
+<!-- ABtools/README.md · v2.3 · 2025-09-01 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -28,6 +28,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
   files by SHA1 hash or by name
 - GUI front-end displays a progress bar with estimated time
 - GUI front-end can run `find_duplicates.py` to scan source and destination for duplicate audio files
+- GUI front-end processes output in batches so the window stays responsive during large scans
 - Planning mode writes a JSON plan that can be reviewed before execution
 - GUI front-end checks that a plan file path is selected before generating or applying a plan
 - Transactions are logged and can be rolled back with `--undo-last`
@@ -55,7 +56,7 @@ pip install -r requirements.txt
 |-------|---------|------|
 
 | `combobook.py` | v1.13 | `ABtools/combobook.py` |
-| `AbtoolsGui.py` | v0.7 | `ABtools/AbtoolsGui.py` |
+| `AbtoolsGui.py` | v0.8 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v5.0 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.16 | `ABtools/search_and_tag.py` |
@@ -121,7 +122,7 @@ Both `combobook.py` and `restructure_for_audiobookshelf.py` can copy books when 
 
 ## `AbtoolsGui.py`
 `AbtoolsGui.py` offers a basic Tkinter interface for `combobook.py`. It provides text fields for selecting the source and library folders, checkboxes matching the `--commit`, `--copy` and `--yes` command-line options, and shows live `combobook` output in a scrolling pane. A progress bar displays overall progress with an estimated time remaining. Beyond the "Tag Only" and "Find Duplicates" helpers, the GUI now exposes buttons to generate restructure plans, apply them atomically, and undo the most recent transaction.
-It validates that a plan file path is chosen before generating or applying a plan to avoid permission errors.
+It validates that a plan file path is chosen before generating or applying a plan to avoid permission errors, and processes queued output in small batches so the window stays responsive during long runs.
 
 ## `search_and_tag.py`
 `search_and_tag.py` tags or strips audiobook files. It queries Audible,

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,4 +1,4 @@
-<!-- ABtools/scaffold.md · v1.5 · 2025-09-01 -->
+<!-- ABtools/scaffold.md · v1.6 · 2025-09-01 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -70,6 +70,7 @@ Audiobooks/
 - "Tag Only" button that runs `search_and_tag.py` without moving files
 - "Find Duplicates" button that scans source and destination using `find_duplicates.py`
 - Buttons to generate restructure plans, apply them atomically and undo the last run
+- Processes output queue in small batches so the window remains responsive during large scans
 
 ### `restructure_for_audiobookshelf.py`
 
@@ -115,7 +116,7 @@ Audiobooks/
 | Script | Version | Path |
 |-------|---------|------|
 | `combobook.py` | v1.13 | `ABtools/combobook.py` |
-| `AbtoolsGui.py` | v0.7 | `ABtools/AbtoolsGui.py` |
+| `AbtoolsGui.py` | v0.8 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v5.0 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.16 | `ABtools/search_and_tag.py` |


### PR DESCRIPTION
## Summary
- Limit `AbtoolsGui` queue polling to 100 messages per tick to prevent freezes.
- Document the change and bump `AbtoolsGui` to v0.8 in README and scaffold.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd667c0f088322801e6eb102f5c8c3