### PR TITLE
Expose Audiobookshelf restructure in GUI and document usage

### DIFF
--- a/AbtoolsGui.py
+++ b/AbtoolsGui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/AbtoolsGui.py  ·  v0.8  ·  2025-09-01
+ABtools/AbtoolsGui.py  ·  v0.11  ·  2025-09-01
 """
 from __future__ import annotations
 
@@ -8,12 +8,12 @@ import sys, threading, queue, time, json
 from collections import defaultdict
 from contextlib import redirect_stdout, redirect_stderr
 import tkinter as tk
-from tkinter import filedialog, messagebox, ttk
+from tkinter import filedialog, messagebox, ttk, scrolledtext
 from pathlib import Path
 from types import SimpleNamespace
-import combobook, search_and_tag, find_duplicates
+import combobook, search_and_tag, find_duplicates, restructure_for_audiobookshelf
 
-VERSION = "0.8"
+VERSION = "0.11"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -68,7 +68,7 @@ tk.Checkbutton(root, text="Yes", variable=yes_var).grid(row=3, column=2, sticky=
 # --- output ---
 output_queue: queue.Queue[tuple[str, object]] = queue.Queue()
 
-output_text = tk.Text(root, height=15, width=60, state="disabled")
+output_text = scrolledtext.ScrolledText(root, height=15, width=60, state="disabled")
 output_text.grid(row=6, column=0, columnspan=4, padx=5, pady=5)
 
 progress_var = tk.IntVar(value=0)
@@ -79,7 +79,7 @@ tk.Label(root, textvariable=eta_var).grid(row=8, column=0, columnspan=4)
 
 def append_output(text: str) -> None:
     output_text.configure(state="normal")
-    output_text.insert(tk.END, text)
+    output_text.insert(tk.END, text.replace("\r", "\n"))
     output_text.see(tk.END)
     output_text.configure(state="disabled")
 
@@ -170,6 +170,64 @@ def run() -> None:
                     combobook.rprint(f"  would_move   : {summary['would_move']}")
                 for k in ("exists", "skip", "unmatched"):
                     combobook.rprint(f"  {k:12}: {summary[k]}")
+            output_queue.put(("status", "done"))
+        except Exception as exc:  # pragma: no cover - handled via GUI
+            output_queue.put(("status", f"error:{exc}"))
+
+    threading.Thread(target=worker, daemon=True).start()
+
+
+def restructure() -> None:
+    src = Path(source_var.get()).expanduser()
+    dst = Path(dest_var.get()).expanduser()
+    if not src.exists():
+        messagebox.showerror("Error", "Source path does not exist")
+        return
+    dst.mkdir(parents=True, exist_ok=True)
+
+    output_text.configure(state="normal")
+    output_text.delete("1.0", tk.END)
+    output_text.configure(state="disabled")
+    progress.configure(maximum=1)
+    progress_var.set(0)
+    eta_var.set("ETA: --:--")
+
+    def worker() -> None:
+        try:
+            with redirect_stdout(QueueWriter(output_queue)), redirect_stderr(
+                QueueWriter(output_queue)
+            ):
+                leaves = restructure_for_audiobookshelf.leaf_audio_dirs(src)
+                total = len(leaves)
+                stats = defaultdict(int)
+                start = time.time()
+                for idx, leaf in enumerate(leaves, 1):
+                    restructure_for_audiobookshelf.process(
+                        leaf,
+                        dst,
+                        dry=not commit_var.get(),
+                        copy=copy_var.get(),
+                        st=stats,
+                        interactive=False,
+                    )
+                    elapsed = time.time() - start
+                    rate = idx / elapsed if elapsed else 0
+                    eta = (total - idx) / rate if rate else 0
+                    output_queue.put(("progress", (idx, total, eta)))
+                print("\n──── Summary ────")
+                action_word = "copied" if copy_var.get() else "moved"
+                print(f" Books scanned            : {stats['total']}")
+                print(f" Books {action_word:20}: {stats['moved']}")
+                if not commit_var.get():
+                    print(f" Books that would move    : {stats['would_move']}")
+                for k, label in (
+                    ("exists", "Destination exists"),
+                    ("no_audio", "No audio"),
+                    ("tag_fail", "Tag/name unreadable"),
+                ):
+                    if stats[k]:
+                        print(f" {label:25}: {stats[k]}")
+                print("──── Done ────\n")
             output_queue.put(("status", "done"))
         except Exception as exc:  # pragma: no cover - handled via GUI
             output_queue.put(("status", f"error:{exc}"))
@@ -299,7 +357,7 @@ def make_plan() -> None:
                 from planning import plan_library
 
                 plan = plan_library(src, dst, copy=copy_var.get())
-                json.dump(plan, open(plan_path, "w"), indent=2)
+                json.dump(plan, open(plan_path, "w", encoding="utf-8"), indent=2)
                 print(f"plan saved to {plan_path}")
             output_queue.put(("status", "done"))
         except Exception as exc:  # pragma: no cover - handled via GUI
@@ -364,8 +422,9 @@ def undo_last_txn() -> None:
 
 
 tk.Button(root, text="Run", command=run).grid(row=4, column=0, pady=10)
-tk.Button(root, text="Tag Only", command=tag_only).grid(row=4, column=1, pady=10)
-tk.Button(root, text="Find Duplicates", command=find_dupes).grid(row=4, column=2, columnspan=2, pady=10)
+tk.Button(root, text="Restructure", command=restructure).grid(row=4, column=1, pady=10)
+tk.Button(root, text="Tag Only", command=tag_only).grid(row=4, column=2, pady=10)
+tk.Button(root, text="Find Duplicates", command=find_dupes).grid(row=4, column=3, pady=10)
 tk.Button(root, text="Plan", command=make_plan).grid(row=5, column=0, pady=10)
 tk.Button(root, text="Apply Plan", command=apply_plan).grid(row=5, column=1, pady=10)
 tk.Button(root, text="Undo Last", command=undo_last_txn).grid(row=5, column=2, pady=10)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ABtools/README.md · v2.3 · 2025-09-01 -->
+<!-- ABtools/README.md · v2.5 · 2025-09-01 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -26,11 +26,12 @@ This repository contains small utilities for preparing audiobook folders for [Au
 - Prints the score from each metadata provider during tagging
 - `find_duplicates.py` shows progress while scanning and can compare
   files by SHA1 hash or by name
-- GUI front-end displays a progress bar with estimated time
+- GUI front-end shows live output in a scrollable pane with a progress bar and estimated time
 - GUI front-end can run `find_duplicates.py` to scan source and destination for duplicate audio files
 - GUI front-end processes output in batches so the window stays responsive during large scans
 - Planning mode writes a JSON plan that can be reviewed before execution
 - GUI front-end checks that a plan file path is selected before generating or applying a plan
+- Plan files are read and written using UTF-8 encoding for cross-platform compatibility
 - Transactions are logged and can be rolled back with `--undo-last`
 - Duplicate catalog prevents importing the same book twice
 
@@ -55,15 +56,15 @@ pip install -r requirements.txt
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.13 | `ABtools/combobook.py` |
-| `AbtoolsGui.py` | v0.8 | `ABtools/AbtoolsGui.py` |
+| `combobook.py` | v1.14 | `ABtools/combobook.py` |
+| `AbtoolsGui.py` | v0.11 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v5.0 | `ABtools/restructure_for_audiobookshelf.py` |
+| `restructure_for_audiobookshelf.py` | v5.2 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.16 | `ABtools/search_and_tag.py` |
 | `find_duplicates.py` | v0.4 | `ABtools/find_duplicates.py` |
 | `abclient.py` | v0.2 | `ABtools/abclient.py` |
-| `planning.py` | v0.1 | `ABtools/planning.py` |
-| `transaction.py` | v0.1 | `ABtools/transaction.py` |
+| `planning.py` | v0.2 | `ABtools/planning.py` |
+| `transaction.py` | v0.2 | `ABtools/transaction.py` |
 | `catalog.py` | v0.1 | `ABtools/catalog.py` |
 
 Run any script with `--version` to print its version and file location.
@@ -75,7 +76,7 @@ It now also collapses folders named like `Book Title (1 of 5)` into a single dir
 
 The source path is now passed explicitly, avoiding `NameError: SRC is not defined` when the script is imported by other modules or run via the GUI.
 
-For a simple graphical front-end, use `AbtoolsGui.py`, which provides text fields for source and destination folders, checkboxes for `--commit`, `--copy` and `--yes` options, a live output pane, and a progress bar with estimated time. It includes a "Tag Only" button that runs `search_and_tag.py` without moving files, a "Find Duplicates" button, and new controls to generate plans, apply them transactionally, or undo the last run.
+For a simple graphical front-end, use `AbtoolsGui.py`, which provides text fields for source and destination folders, checkboxes for `--commit`, `--copy` and `--yes` options, a live output pane, and a progress bar with estimated time. It includes a "Restructure" button for reorganizing folders, a "Tag Only" button that runs `search_and_tag.py` without moving files, a "Find Duplicates" button, and new controls to generate plans, apply them transactionally, or undo the last run.
 
 FFmpeg tag writing previously failed silently; the script now specifies the output file so tags are embedded correctly.
 
@@ -121,7 +122,7 @@ Folders are moved to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`
 Both `combobook.py` and `restructure_for_audiobookshelf.py` can copy books when run with `--copy` alongside `--commit`.
 
 ## `AbtoolsGui.py`
-`AbtoolsGui.py` offers a basic Tkinter interface for `combobook.py`. It provides text fields for selecting the source and library folders, checkboxes matching the `--commit`, `--copy` and `--yes` command-line options, and shows live `combobook` output in a scrolling pane. A progress bar displays overall progress with an estimated time remaining. Beyond the "Tag Only" and "Find Duplicates" helpers, the GUI now exposes buttons to generate restructure plans, apply them atomically, and undo the most recent transaction.
+`AbtoolsGui.py` offers a basic Tkinter interface for `combobook.py`. It provides text fields for selecting the source and library folders, checkboxes matching the `--commit`, `--copy` and `--yes` command-line options, and shows live `combobook` output in a scrolling pane. Progress messages that rely on carriage returns are normalized so each update appears on its own line. A progress bar displays overall progress with an estimated time remaining. Alongside buttons for "Restructure", "Tag Only" and "Find Duplicates", the GUI exposes controls to generate restructure plans, apply them atomically, and undo the most recent transaction.
 It validates that a plan file path is chosen before generating or applying a plan to avoid permission errors, and processes queued output in small batches so the window stays responsive during long runs.
 
 ## `search_and_tag.py`
@@ -148,6 +149,20 @@ details.
 
 ## `restructure_for_audiobookshelf.py`
 `restructure_for_audiobookshelf.py` reorganizes a source collection into Audiobookshelf layout. It reads tags from the audio files first, then `metadata.json` or `book.nfo`, and finally falls back to folder names. Disc folders are flattened and books are moved or copied to `<library>/Author/Series?/Vol # - YYYY - Title {Narrator}/`. Series names and volume numbers are detected with fuzzy matching (e.g. `Book 3`, `#3`, `Volume III`). When run with `--interactive`, the script prompts for missing series info. Metadata matching is handled by `search_and_tag.py`. Track renaming now avoids collisions by staging files with temporary names first.
+
+Examples:
+
+```bash
+# preview
+python restructure_for_audiobookshelf.py "Downloads" "Audiobooks"
+
+# move folders
+python restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --commit
+
+# plan then apply
+python restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --plan-json plan.json
+python restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --apply-plan plan.json
+```
 
 ## `find_duplicates.py`
 `find_duplicates.py` scans a folder recursively and can find duplicates either by computing SHA1 hashes or by matching file names. Progress is shown while scanning. Results are written to `duplicate_log.txt` inside the scanned folder. Use `--version` to show the script version and path. Hash matching now skips hashing files with unique sizes for much faster scans.

--- a/combobook.py
+++ b/combobook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/combobook.py  ·  v1.13  ·  2025-09-01
+ABtools/combobook.py  ·  v1.14  ·  2025-09-01
 
 USAGE
 -----
@@ -39,7 +39,7 @@ from typing import List, Optional
 from difflib import SequenceMatcher
 import errno
 
-VERSION = "1.13"
+VERSION = "1.14"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -614,7 +614,7 @@ if __name__=="__main__":
     if args.plan_json:
         from planning import plan_library
         plan = plan_library(src, lib, copy=args.copy)
-        json.dump(plan, open(args.plan_json, "w"), indent=2)
+        json.dump(plan, open(args.plan_json, "w", encoding="utf-8"), indent=2)
         sys.exit(0)
     AUTO_YES = args.yes
     main(src, lib, args.commit, args.yes, args.copy)

--- a/planning.py
+++ b/planning.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-ABtools/planning.py · v0.1 · 2025-09-01
+ABtools/planning.py · v0.2 · 2025-09-01
 Builds restructure plans for audiobook libraries.
 """
 from __future__ import annotations
-import json, re, hashlib
+import json, re, hashlib, sys
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -13,6 +13,14 @@ from catalog import Catalog
 
 AUDIO_EXTS = {".mp3", ".m4b", ".m4a", ".flac", ".ogg", ".opus"}
 SIDE_EXTS = {".cue", ".pdf", "metadata.json", "book.nfo"}
+
+VERSION = "0.2"
+FILE_PATH = Path(__file__).resolve()
+VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
+
+if "--version" in sys.argv:
+    print(VERSION_INFO % {"prog": Path(sys.argv[0]).name})
+    sys.exit(0)
 
 @dataclass
 class PlanEntry:
@@ -55,7 +63,7 @@ def plan_library(src_root: Path, dest_root: Path, copy: bool = False) -> List[Di
     plan: List[Dict] = []
     for book in leaf_audio_dirs(src_root):
         meta_path = book / "metadata.json"
-        meta = json.load(meta_path.open()) if meta_path.exists() else {}
+        meta = json.load(meta_path.open(encoding="utf-8")) if meta_path.exists() else {}
         author = meta.get("author", "Unknown")
         title = meta.get("title", book.name)
         provider = meta.get("provider", "mock")
@@ -89,7 +97,7 @@ def plan_library(src_root: Path, dest_root: Path, copy: bool = False) -> List[Di
     return plan
 
 if __name__ == "__main__":
-    import argparse, sys
+    import argparse
     ap = argparse.ArgumentParser(description="Build plan for library")
     ap.add_argument("src")
     ap.add_argument("dest")
@@ -98,6 +106,6 @@ if __name__ == "__main__":
     args = ap.parse_args()
     p = plan_library(Path(args.src), Path(args.dest), copy=args.copy)
     if args.plan_json:
-        json.dump(p, open(args.plan_json, "w"), indent=2)
+        json.dump(p, open(args.plan_json, "w", encoding="utf-8"), indent=2)
     else:
         json.dump(p, sys.stdout, indent=2)

--- a/restructure_for_audiobookshelf.py
+++ b/restructure_for_audiobookshelf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/restructure_for_audiobookshelf.py – v5.0  (2025-09-01)
+ABtools/restructure_for_audiobookshelf.py – v5.2  (2025-09-01)
 Use restructure_for_audiobookshelf.py "Source folder" "Destination folder" --commit 
 • Recursively scans source_root; every directory that *contains* audio but whose
   sub-directories don’t is treated as one “book”.
@@ -21,6 +21,14 @@ Use restructure_for_audiobookshelf.py "Source folder" "Destination folder" --com
 • Fuzzy series matching ("Book 3", "#3", "Volume III", etc.)
 • ``--interactive`` prompts for series info when uncertain
 • Part suffixes like “(1 of 6)” or “Part 1” are preserved when moving
+
+Examples::
+
+    restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --commit
+    restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --commit --copy
+    restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --plan-json plan.json
+    restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --apply-plan plan.json
+    restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --undo-last
 """
 
 from __future__ import annotations
@@ -31,7 +39,7 @@ from pathlib import Path
 from typing import List, Optional
 import xml.etree.ElementTree as ET
 
-VERSION = "5.0"
+VERSION = "5.2"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -512,9 +520,21 @@ if __name__ == "__main__":
         action="store_true",
         help="Prompt for series info when not detected",
     )
-    ap.add_argument("--plan-json")
-    ap.add_argument("--apply-plan")
-    ap.add_argument("--undo-last", action="store_true")
+    ap.add_argument(
+        "--plan-json",
+        metavar="PATH",
+        help="write restructure plan to PATH and exit",
+    )
+    ap.add_argument(
+        "--apply-plan",
+        metavar="PATH",
+        help="apply moves from plan at PATH and exit",
+    )
+    ap.add_argument(
+        "--undo-last",
+        action="store_true",
+        help="rollback the most recent transaction and exit",
+    )
     ap.add_argument("--version", action="version", version=VERSION_INFO)
     args = ap.parse_args()
 
@@ -544,6 +564,6 @@ if __name__ == "__main__":
     if args.plan_json:
         from planning import plan_library
         plan = plan_library(src, dst, copy=args.copy)
-        json.dump(plan, open(args.plan_json, "w"), indent=2)
+        json.dump(plan, open(args.plan_json, "w", encoding="utf-8"), indent=2)
         sys.exit(0)
     main(src, dst, args.commit, args.copy, args.interactive)

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,4 +1,4 @@
-<!-- ABtools/scaffold.md · v1.6 · 2025-09-01 -->
+<!-- ABtools/scaffold.md · v1.8 · 2025-09-01 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -66,11 +66,13 @@ Audiobooks/
 - Simple Tkinter GUI front-end for `combobook.py`
 - Text fields for source and library folders
 - Checkboxes for `--commit`, `--copy` and `--yes`
-- Live output pane and progress bar with estimated time
+- Scrollable output pane and progress bar with estimated time
 - "Tag Only" button that runs `search_and_tag.py` without moving files
 - "Find Duplicates" button that scans source and destination using `find_duplicates.py`
+- "Restructure" button that reorganizes folders via `restructure_for_audiobookshelf.py`
 - Buttons to generate restructure plans, apply them atomically and undo the last run
 - Processes output queue in small batches so the window remains responsive during large scans
+- Saves plan files with UTF-8 encoding for cross-platform compatibility
 
 ### `restructure_for_audiobookshelf.py`
 
@@ -82,6 +84,20 @@ Audiobooks/
 - Detects fuzzy series numbering ("Book 2", "#2", "Volume II")
 - `--interactive` prompts for series info when unclear
 - Handles source folders with spaces without quoting
+
+Examples:
+
+```bash
+# preview
+python restructure_for_audiobookshelf.py "Downloads" "Audiobooks"
+
+# commit changes
+python restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --commit
+
+# create and apply plan
+python restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --plan-json plan.json
+python restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --apply-plan plan.json
+```
 
 ### `find_duplicates.py`
 
@@ -115,14 +131,14 @@ Audiobooks/
 
 | Script | Version | Path |
 |-------|---------|------|
-| `combobook.py` | v1.13 | `ABtools/combobook.py` |
-| `AbtoolsGui.py` | v0.8 | `ABtools/AbtoolsGui.py` |
+| `combobook.py` | v1.14 | `ABtools/combobook.py` |
+| `AbtoolsGui.py` | v0.11 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
-| `restructure_for_audiobookshelf.py` | v5.0 | `ABtools/restructure_for_audiobookshelf.py` |
+| `restructure_for_audiobookshelf.py` | v5.2 | `ABtools/restructure_for_audiobookshelf.py` |
 | `search_and_tag.py` | v2.16 | `ABtools/search_and_tag.py` |
 | `find_duplicates.py` | v0.4 | `ABtools/find_duplicates.py` |
 | `abclient.py` | v0.2 | `ABtools/abclient.py` |
-| `planning.py` | v0.1 | `ABtools/planning.py` |
-| `transaction.py` | v0.1 | `ABtools/transaction.py` |
+| `planning.py` | v0.2 | `ABtools/planning.py` |
+| `transaction.py` | v0.2 | `ABtools/transaction.py` |
 | `catalog.py` | v0.1 | `ABtools/catalog.py` |
 

--- a/transaction.py
+++ b/transaction.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
 """
-ABtools/transaction.py · v0.1 · 2025-09-01
+ABtools/transaction.py · v0.2 · 2025-09-01
 Apply and rollback restructure plans.
 """
 from __future__ import annotations
-import json, shutil, hashlib, time
+import json, shutil, hashlib, time, sys
 from pathlib import Path
 from typing import List, Dict
+
+VERSION = "0.2"
+FILE_PATH = Path(__file__).resolve()
+VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
+
+if "--version" in sys.argv:
+    print(VERSION_INFO % {"prog": Path(sys.argv[0]).name})
+    sys.exit(0)
 
 AUDIO_EXTS = {".mp3", ".m4b", ".m4a", ".flac", ".ogg", ".opus"}
 SIDE_RX = (".cue", ".pdf", "metadata.json", "book.nfo")
@@ -21,7 +29,7 @@ def sha1(path: Path) -> str:
 
 
 def execute(plan_file: Path) -> Path:
-    plan = json.load(open(plan_file))
+    plan = json.load(open(plan_file, encoding="utf-8"))
     txndir = Path("transactions")
     txndir.mkdir(exist_ok=True)
     txn_path = txndir / f"txn-{int(time.time())}.json"
@@ -41,14 +49,14 @@ def execute(plan_file: Path) -> Path:
         # mark metadata
         meta = dest / "metadata.json"
         if meta.exists():
-            data = json.load(meta.open())
+            data = json.load(meta.open(encoding="utf-8"))
             data["abtools_processed"] = True
-            json.dump(data, meta.open("w"), indent=2)
+            json.dump(data, meta.open("w", encoding="utf-8"), indent=2)
         # record sha1 of first file
         files = [p for p in dest.rglob("*") if p.is_file()]
         digest = sha1(files[0]) if files else ""
         records.append({"src": str(src), "dst": str(dest), "sha1": digest})
-    json.dump(records, txn_path.open("w"), indent=2)
+    json.dump(records, txn_path.open("w", encoding="utf-8"), indent=2)
     return txn_path
 
 
@@ -61,7 +69,7 @@ def undo_last(txndir: Path = Path("transactions")) -> None:
         print("no transactions")
         return
     last = files[-1]
-    moves = json.load(last.open())
+    moves = json.load(last.open(encoding="utf-8"))
     for mv in reversed(moves):
         dst = Path(mv["dst"])
         src = Path(mv["src"])


### PR DESCRIPTION
## Summary
- add "Restructure" button to GUI to reorganize folders via `restructure_for_audiobookshelf`
- document Audiobookshelf helper with CLI help text, examples, and version bumps
- update README and scaffold tables with new versions and GUI description

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6ad2f2f88322b5e964064b8141b6