### PR TITLE
Add GPT fallback metadata tagging to combobook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- ABtools/README.md · v2.8 · 2025-09-04 -->
+<!-- ABtools/README.md · v2.9 · 2025-09-04 -->
 # Audiobook Organizer & Tagger
 
 This repository contains small utilities for preparing audiobook folders for [Audiobookshelf](https://www.audiobookshelf.org/).
@@ -17,6 +17,7 @@ This repository contains small utilities for preparing audiobook folders for [Au
 - Fetches metadata in parallel for faster tagging
 - Ranks matches using both title and author similarity for better accuracy
 - Optional GPT4All fallback can propose metadata when lookups fail or are low-confidence (`--llm-model`/`--llm-threshold`) and now feeds it a Faster-Whisper transcript of the first minute with configurable device/compute options for GPU acceleration
+- `combobook.py` now reuses the GPT4All fallback to supply metadata when provider searches fail, tags the files automatically, and logs AI-assisted folders for later review
 - Preserves part numbers like `(1 of 6)` when reorganizing files
 - Adds track numbers so multi-part books play in order
 - Detects series and volume numbers with fuzzy matching
@@ -62,7 +63,7 @@ pip install -r requirements.txt
 | Script | Version | Path |
 |-------|---------|------|
 
-| `combobook.py` | v1.14 | `ABtools/combobook.py` |
+| `combobook.py` | v1.15 | `ABtools/combobook.py` |
 | `AbtoolsGui.py` | v0.11 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v5.2 | `ABtools/restructure_for_audiobookshelf.py` |
@@ -76,7 +77,7 @@ pip install -r requirements.txt
 Run any script with `--version` to print its version and file location.
 
 ## `combobook.py`
-`combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files. When no match is found, the folder is moved into an `_unmatched` directory inside your library for later review.
+`combobook.py` tags, flattens and moves audiobook folders in a single pass. It searches Open Library, Google Books and Audible, ranks potential matches using fuzzy similarity and asks you to confirm before tagging and moving files. When provider lookups and prompts fail, the script now consults the shared GPT4All fallback to propose metadata, tags every track automatically, and logs which folders used the AI assist. Only when both paths fail does it fall back to moving the folder into an `_unmatched` directory inside your library for manual review.
 
 It now also collapses folders named like `Book Title (1 of 5)` into a single directory and names each file `Part 01`, `Part 02`, etc.
 

--- a/combobook.py
+++ b/combobook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-ABtools/combobook.py  ·  v1.14  ·  2025-09-01
+ABtools/combobook.py  ·  v1.15  ·  2025-09-04
 
 USAGE
 -----
@@ -40,7 +40,9 @@ from difflib import SequenceMatcher
 import errno
 from difflib import SequenceMatcher
 
-VERSION = "1.14"
+from search_and_tag import generate_metadata_via_llm
+
+VERSION = "1.15"
 FILE_PATH = Path(__file__).resolve()
 VERSION_INFO = f"%(prog)s v{VERSION} ({FILE_PATH})"
 
@@ -511,12 +513,46 @@ def process(folder: Path, src: Path, lib: Path, dry: bool, yes: bool, copy: bool
         guess = guess_from_folder(folder)
         # Prompt the user (or auto‐yes) for a match
         hit = choose_meta(guess)
-        if not hit:
-            rprint("[yellow]• no metadata match:[/]", folder.relative_to(src))
+        chosen_meta = hit
+        llm_used = False
+        if not chosen_meta:
+            llm_payload = generate_metadata_via_llm(folder, audio_files)
+            if llm_payload:
+                author = (llm_payload.get("author") or "").strip()
+                title = (llm_payload.get("title") or "").strip()
+                if author and title:
+                    series = llm_payload.get("series") or None
+                    if isinstance(series, str):
+                        series = series.strip() or None
+                    seq = llm_payload.get("series_index") or None
+                    if seq is not None:
+                        seq = str(seq).strip() or None
+                    year = llm_payload.get("year") or None
+                    if isinstance(year, str):
+                        year = year.strip() or None
+                    narr = llm_payload.get("narrator") or None
+                    if isinstance(narr, str):
+                        narr = narr.strip() or None
+                    chosen_meta = Meta(
+                        author=author,
+                        title=title,
+                        year=year,
+                        series=series,
+                        seq=seq,
+                        narr=narr,
+                    )
+                    llm_used = True
+
+        if not chosen_meta:
+            try:
+                rel = folder.relative_to(src)
+            except ValueError:
+                rel = folder
+            rprint("[yellow]• no metadata match:[/]", rel)
             summary["unmatched"] += 1
             dest = lib / UNMATCHED_DIR / slug(folder.name)
             action = 'cp' if copy else 'mv'
-            rprint(f"{action if not dry else '↪'} {folder.relative_to(src)} → {dest.relative_to(lib)}")
+            rprint(f"{action if not dry else '↪'} {rel} → {dest.relative_to(lib)}")
             if dry:
                 summary["would_move"] += 1
                 if FLATTEN_DISCS:
@@ -532,10 +568,18 @@ def process(folder: Path, src: Path, lib: Path, dry: bool, yes: bool, copy: bool
             summary["moved"] += 1
             return
 
-        # Write tags to all tracks in this folder
+        if llm_used:
+            try:
+                rel = folder.relative_to(src)
+            except ValueError:
+                rel = folder
+            rprint(
+                f"[magenta]• metadata via LLM fallback:[/] {rel} → {chosen_meta.title} by {chosen_meta.author}"
+            )
+
         for idx, t in enumerate(audio_files, 1):
-            write_tags(t, hit, idx, len(audio_files))
-        meta = hit
+            write_tags(t, chosen_meta, idx, len(audio_files))
+        meta = chosen_meta
 
     # 4) At this point 'meta' is guaranteed to contain author/title, etc.
     #    We can flatten / rename / move as before.

--- a/scaffold.md
+++ b/scaffold.md
@@ -1,4 +1,4 @@
-<!-- ABtools/scaffold.md · v2.1 · 2025-09-04 -->
+<!-- ABtools/scaffold.md · v2.2 · 2025-09-04 -->
 # Audiobook Tagging & Organization – Scaffold
 
 ## Project Structure
@@ -53,11 +53,12 @@ Audiobooks/
 ### `combobook.py`
 
 - Combines the functionality of both scripts:
-  - Detects audio files
-  - Tags them using `search_and_tag.py` logic
-  - Creates cleaned-up `Author/Year - Title` folder
-  - Moves and renames content
-    - Unmatched folders are moved into an `_unmatched` directory for manual review
+    - Detects audio files
+    - Tags them using `search_and_tag.py` logic
+    - Calls the shared GPT4All fallback when provider lookups fail, tagging tracks automatically and logging AI-assisted folders
+    - Creates cleaned-up `Author/Year - Title` folder
+    - Moves and renames content
+    - Only moves folders into `_unmatched` when both provider searches and the GPT4All fallback fail
     - Embeds tags with FFmpeg; fixed missing output file to ensure tags are written
     - Accepts source paths with spaces without needing quotes
     - Passes the source path explicitly to avoid `NameError: SRC is not defined` when imported elsewhere
@@ -140,7 +141,7 @@ python restructure_for_audiobookshelf.py "Downloads" "Audiobooks" --apply-plan p
 
 | Script | Version | Path |
 |-------|---------|------|
-| `combobook.py` | v1.14 | `ABtools/combobook.py` |
+| `combobook.py` | v1.15 | `ABtools/combobook.py` |
 | `AbtoolsGui.py` | v0.11 | `ABtools/AbtoolsGui.py` |
 | `flatten_discs.py` | v1.4 | `ABtools/flatten_discs.py` |
 | `restructure_for_audiobookshelf.py` | v5.2 | `ABtools/restructure_for_audiobookshelf.py` |


### PR DESCRIPTION
## Summary
- integrate the shared `generate_metadata_via_llm` helper into `combobook.py` so folders without provider matches are tagged with LLM metadata and logged before falling back to `_unmatched`
- document the new fallback behaviour and updated script version in the README and scaffold guides

## Testing
- python -m compileall combobook.py

------
https://chatgpt.com/codex/tasks/task_e_68dac25d4f6883229bf43a2e3ff32389